### PR TITLE
Priority fixes: auth leftovers, known bugs, query-key consolidation

### DIFF
--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -186,7 +186,17 @@ def sign_out(request: Request, response: Response):
         except Exception:
             pass  # revocation is best-effort; always clear the cookie regardless
 
-    response.delete_cookie("auth_token")
+    # The deletion Set-Cookie must carry the same secure/samesite attributes as
+    # the signin cookie: in production the cookie is SameSite=None; Secure, and
+    # browsers reject a cross-site deletion header that lacks those flags,
+    # leaving the user logged in.
+    is_production = os.getenv("ENVIRONMENT", "development") == "production"
+    response.delete_cookie(
+        "auth_token",
+        httponly=True,
+        secure=is_production,
+        samesite="lax" if not is_production else "none",
+    )
     return {"message": "Logged out successfully"}
 
 @router.post("/api/v1/forgot-password")

--- a/src/features/admin/components/RejectDialog.tsx
+++ b/src/features/admin/components/RejectDialog.tsx
@@ -26,14 +26,10 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import type { RejectReason } from "@/types/domain";
+import { REJECT_REASON_LABELS } from "@/lib/constants";
 
-const REJECT_REASONS: { value: RejectReason; label: string }[] = [
-    { value: "DUPLICATE", label: "Duplicate content" },
-    { value: "OUTDATED", label: "Outdated material" },
-    { value: "INCORRECT_COURSE", label: "Incorrect course/category" },
-    { value: "BAD_QUALITY", label: "Poor quality" },
-    { value: "OTHER", label: "Other reason" },
-];
+const REJECT_REASONS = (Object.entries(REJECT_REASON_LABELS) as [RejectReason, string][])
+    .map(([value, label]) => ({ value, label }));
 
 interface RejectDialogProps {
     open: boolean;

--- a/src/features/admin/components/RequestDetailSheet.tsx
+++ b/src/features/admin/components/RequestDetailSheet.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/ui/collapsible";
 import { RejectDialog } from "./RejectDialog";
 import type { FileRequest, RejectReason } from "@/types/domain";
+import { rejectReasonLabel } from "@/lib/constants";
 
 interface RequestDetailSheetProps {
     request: FileRequest | null;
@@ -248,7 +249,7 @@ export function RequestDetailSheet({
                         {request.status === "rejected" && request.rejectionReason && (
                             <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 space-y-1">
                                 <p className="text-sm font-medium text-red-300">Rejection Reason</p>
-                                <p className="text-sm text-red-400">{request.rejectionReason}</p>
+                                <p className="text-sm text-red-400">{rejectReasonLabel(request.rejectionReason)}</p>
                                 {request.rejectionNote && (
                                     <p className="text-sm text-red-400/80 mt-2">{request.rejectionNote}</p>
                                 )}

--- a/src/features/admin/hooks/useAudit.ts
+++ b/src/features/admin/hooks/useAudit.ts
@@ -8,12 +8,13 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 import { listAuditLogs, type AuditLogFilters } from "@/features/admin/api/auditService";
 
 /**
  * Fetches audit log entries with optional filters.
  */
 export const useAuditLogs = (filters?: AuditLogFilters) => useQuery({
-    queryKey: ['audit-logs', filters],
+    queryKey: queryKeys.audit.filtered(filters),
     queryFn: () => listAuditLogs(filters)
 });

--- a/src/features/auth/api/authService.ts
+++ b/src/features/auth/api/authService.ts
@@ -95,11 +95,11 @@ export interface SignUpPayload {
 }
 
 export const authService = {
-    signIn: async ({ email, password }: SignInPayload): Promise<SignInResponse> => {
+    signIn: async ({ email, password, rememberMe = false }: SignInPayload): Promise<SignInResponse> => {
         try {
             const data = await api<SignInResponse>("/signin", {
                 method: "POST",
-                body: JSON.stringify({ email, password }),
+                body: JSON.stringify({ email, password, remember_me: rememberMe }),
             });
             return { user: data.user };
         } catch (err: unknown) {

--- a/src/features/courses/hooks/useCatalog.ts
+++ b/src/features/courses/hooks/useCatalog.ts
@@ -67,7 +67,7 @@ export const useMajors = () => useQuery({
  * @param majorId - Optional filter (for future use)
  */
 export const useYears = (majorId?: string) => useQuery({
-    queryKey: ['years', majorId],
+    queryKey: queryKeys.catalog.years(majorId),
     queryFn: () => listYears(majorId),
     enabled: true,
     staleTime: Infinity,
@@ -78,7 +78,7 @@ export const useYears = (majorId?: string) => useQuery({
  * @param majorId - Filter by major (enables cascading dropdown)
  */
 export const useSemesters = (majorId?: string) => useQuery({
-    queryKey: ['semesters', majorId],
+    queryKey: queryKeys.catalog.semesters(majorId),
     queryFn: () => listSemesters(majorId),
     enabled: !!majorId
 });
@@ -98,7 +98,7 @@ export const useCourses = (filters: Parameters<typeof listCourses>[0]) => useQue
  * @param courseId - The course ID to fetch
  */
 export const useCourse = (courseId: string) => useQuery({
-    queryKey: ['course', courseId],
+    queryKey: queryKeys.catalog.course(courseId),
     queryFn: () => getCourse(courseId),
     enabled: !!courseId
 });

--- a/src/features/courses/hooks/usePinnedCourses.ts
+++ b/src/features/courses/hooks/usePinnedCourses.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/apiClient";
+import { queryKeys } from "@/lib/queryKeys";
 
 function listPinnedCourses(): Promise<string[]> {
     return api<string[]>("/me/pinned-courses");
@@ -17,7 +18,7 @@ export function usePinnedCourses() {
     const qc = useQueryClient();
 
     const { data: pinnedIds = [] } = useQuery({
-        queryKey: ["pinned-courses"],
+        queryKey: queryKeys.pinnedCourses.all(),
         queryFn: listPinnedCourses,
     });
 
@@ -25,18 +26,18 @@ export function usePinnedCourses() {
         mutationFn: ({ courseId, pinned }: { courseId: string; pinned: boolean }) =>
             pinned ? unpinCourse(courseId) : pinCourse(courseId),
         onMutate: async ({ courseId, pinned }) => {
-            await qc.cancelQueries({ queryKey: ["pinned-courses"] });
-            const prev = qc.getQueryData<string[]>(["pinned-courses"]) ?? [];
+            await qc.cancelQueries({ queryKey: queryKeys.pinnedCourses.all() });
+            const prev = qc.getQueryData<string[]>(queryKeys.pinnedCourses.all()) ?? [];
             qc.setQueryData<string[]>(
-                ["pinned-courses"],
+                queryKeys.pinnedCourses.all(),
                 pinned ? prev.filter(id => id !== courseId) : [...prev, courseId]
             );
             return { prev };
         },
         onError: (_err, _vars, ctx) => {
-            if (ctx?.prev) qc.setQueryData(["pinned-courses"], ctx.prev);
+            if (ctx?.prev) qc.setQueryData(queryKeys.pinnedCourses.all(), ctx.prev);
         },
-        onSettled: () => qc.invalidateQueries({ queryKey: ["pinned-courses"] }),
+        onSettled: () => qc.invalidateQueries({ queryKey: queryKeys.pinnedCourses.all() }),
     });
 
     const togglePin = (courseId: string) =>

--- a/src/features/courses/pages/Courses.tsx
+++ b/src/features/courses/pages/Courses.tsx
@@ -13,6 +13,7 @@ import { useFiles, useTopContributors } from "@/features/files/hooks/useFiles";
 import { BadgeChip } from "@/features/gamification/components/BadgeChip";
 import { usePinnedCourses } from "@/features/courses/hooks/usePinnedCourses";
 import { useAuth } from "@/features/auth/context/AuthContext";
+import { rejectReasonLabel } from "@/lib/constants";
 
 /** Rank-circle styling — gold/silver/bronze for the top three, muted otherwise. */
 const rankStyle = (index: number): string => {
@@ -305,8 +306,8 @@ export default function Courses() {
                                             </p>
                                             <div className="flex items-center gap-2 text-[12px] text-muted-foreground/70 mt-0.5">
                                                 <span>{file.materialYear}</span>
-                                                {file.status === "rejected" && (
-                                                    <span className="text-red-400">• {file.rejectionReason}</span>
+                                                {file.status === "rejected" && file.rejectionReason && (
+                                                    <span className="text-red-400">• {rejectReasonLabel(file.rejectionReason)}</span>
                                                 )}
                                             </div>
                                         </div>

--- a/src/features/directory/hooks/useDirectory.ts
+++ b/src/features/directory/hooks/useDirectory.ts
@@ -59,7 +59,7 @@ export const useUpdateUser = () => {
     return useMutation({
         mutationFn: ({ id, data }: { id: string; data: UserUpdateInput }) => updateUser(id, data),
         onSuccess: () => {
-            qc.invalidateQueries({ queryKey: ["directory", "users"] });
+            qc.invalidateQueries({ queryKey: k.usersRoot() });
             qc.invalidateQueries({ queryKey: k.stats() });
             toast.success("User updated");
         },
@@ -72,7 +72,7 @@ export const useDeleteUser = () => {
     return useMutation({
         mutationFn: (id: string) => deleteUser(id),
         onSuccess: () => {
-            qc.invalidateQueries({ queryKey: ["directory", "users"] });
+            qc.invalidateQueries({ queryKey: k.usersRoot() });
             qc.invalidateQueries({ queryKey: k.stats() });
             toast.success("User deleted");
         },
@@ -85,7 +85,7 @@ export const useDeleteUser = () => {
 /** Refresh the directory major list, the public catalog majors list, and stats. */
 const invalidateMajors = (qc: ReturnType<typeof useQueryClient>) => {
     qc.invalidateQueries({ queryKey: k.majors() });
-    qc.invalidateQueries({ queryKey: ["majors"] }); // shared public catalog dropdowns
+    qc.invalidateQueries({ queryKey: queryKeys.catalog.majors() }); // shared public catalog dropdowns
     qc.invalidateQueries({ queryKey: k.stats() });
 };
 

--- a/src/features/files/hooks/useFiles.ts
+++ b/src/features/files/hooks/useFiles.ts
@@ -31,6 +31,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 import { listFiles, getFile, listTopContributors, listRecentFiles, addRecentFile, clearRecentFiles } from "@/features/files/api/fileService";
 import type { FileFilters } from "@/features/files/api/fileService";
 
@@ -39,7 +40,7 @@ import type { FileFilters } from "@/features/files/api/fileService";
  * @param filters - Filter by courseId, lecturerId, type
  */
 export const useFiles = (filters: FileFilters) => useQuery({
-    queryKey: ['files', filters],
+    queryKey: queryKeys.files.list(filters),
     queryFn: () => listFiles(filters),
     enabled: !!filters.courseId
 });
@@ -49,7 +50,7 @@ export const useFiles = (filters: FileFilters) => useQuery({
  * @param fileId - The file ID to fetch
  */
 export const useFile = (fileId: string) => useQuery({
-    queryKey: ['file', fileId],
+    queryKey: queryKeys.files.detail(fileId),
     queryFn: () => getFile(fileId),
     enabled: !!fileId
 });
@@ -59,7 +60,7 @@ export const useFile = (fileId: string) => useQuery({
  * Cached for 10 minutes as this data doesn't need frequent updates.
  */
 export const useTopContributors = () => useQuery({
-    queryKey: ['top-contributors'],
+    queryKey: queryKeys.files.topContributors(),
     queryFn: listTopContributors,
     staleTime: 1000 * 60 * 10 // 10 minutes
 });
@@ -69,7 +70,7 @@ export const useTopContributors = () => useQuery({
  * @backend When authenticated, backend filters by current user automatically
  */
 export const useRecentFiles = () => useQuery({
-    queryKey: ['recent-files'],
+    queryKey: queryKeys.myFiles.recent(),
     queryFn: listRecentFiles,
 });
 
@@ -82,7 +83,7 @@ export const useAddRecentFile = () => {
     return useMutation({
         mutationFn: addRecentFile,
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['recent-files'] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.myFiles.recent() });
         }
     });
 };
@@ -96,7 +97,7 @@ export const useClearRecentFiles = () => {
     return useMutation({
         mutationFn: clearRecentFiles,
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['recent-files'] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.myFiles.recent() });
         }
     });
 };

--- a/src/features/files/hooks/useRequests.ts
+++ b/src/features/files/hooks/useRequests.ts
@@ -76,7 +76,7 @@ export const useCreateRequest = () => {
         mutationFn: createFileRequest,
         onSuccess: () => {
             // Stable key — no userId segment needed anymore
-            queryClient.invalidateQueries({ queryKey: ["my-requests"] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.requests.mine() });
             toast.success("File submitted successfully");
         },
         onError: (err) => {
@@ -96,7 +96,7 @@ export const useWithdrawRequest = () => {
         mutationFn: ({ requestId }: { requestId: string }) =>
             withdrawRequest(requestId),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["my-requests"] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.requests.mine() });
             toast.success("Request withdrawn");
         },
         onError: () => {
@@ -157,9 +157,9 @@ export const useApproveRequest = () => {
     const queryClient = useQueryClient();
 
     const invalidateAdmin = () => {
-        queryClient.invalidateQueries({ queryKey: ["admin-requests"] });
-        queryClient.invalidateQueries({ queryKey: ["admin-request-stats"] });
-        queryClient.invalidateQueries({ queryKey: ["audit-logs"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.requests.all() });
+        queryClient.invalidateQueries({ queryKey: queryKeys.requests.stats() });
+        queryClient.invalidateQueries({ queryKey: queryKeys.audit.all() });
     };
 
     return useMutation({
@@ -195,9 +195,9 @@ export const useRejectRequest = () => {
     const queryClient = useQueryClient();
 
     const invalidateAdmin = () => {
-        queryClient.invalidateQueries({ queryKey: ["admin-requests"] });
-        queryClient.invalidateQueries({ queryKey: ["admin-request-stats"] });
-        queryClient.invalidateQueries({ queryKey: ["audit-logs"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.requests.all() });
+        queryClient.invalidateQueries({ queryKey: queryKeys.requests.stats() });
+        queryClient.invalidateQueries({ queryKey: queryKeys.audit.all() });
     };
 
     return useMutation({

--- a/src/features/gamification/hooks/useLearningPath.ts
+++ b/src/features/gamification/hooks/useLearningPath.ts
@@ -1,4 +1,5 @@
 ﻿import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 import { getActivitySummary } from "@/features/gamification/api/learningPathService";
 import type { ActivitySummary } from "@/types/domain";
 import { useAuth } from "@/features/auth/context/AuthContext";
@@ -8,7 +9,7 @@ export const useActivitySummary = () => {
     const { user } = useAuth();
 
     return useQuery<ActivitySummary>({
-        queryKey: ["activity-summary"],
+        queryKey: queryKeys.activity.summary(),
         queryFn: getActivitySummary,
         enabled: !!user,
         staleTime: 60 * 1000, // 1 minute fresh

--- a/src/features/gamification/hooks/useReputation.ts
+++ b/src/features/gamification/hooks/useReputation.ts
@@ -48,6 +48,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 import { getMyReputation } from "@/features/gamification/api/reputationService";
 
 /**
@@ -56,7 +57,7 @@ import { getMyReputation } from "@/features/gamification/api/reputationService";
  * @backend When authenticated, backend uses session user automatically
  */
 export const useReputation = (userId: string) => useQuery({
-    queryKey: ['reputation', userId],
+    queryKey: queryKeys.reputation.user(userId),
     queryFn: () => getMyReputation(userId),
     enabled: !!userId
 });

--- a/src/features/profile/pages/UserProfile.tsx
+++ b/src/features/profile/pages/UserProfile.tsx
@@ -156,7 +156,7 @@ export default function UserProfile() {
                                     <Tooltip>
                                         <TooltipTrigger asChild>
                                             <div className="flex items-baseline gap-1.5 cursor-default group w-fit">
-                                                <span className="text-4xl font-light font-display text-foreground tracking-tight group-hover:text-amber-500 transition-colors">{user.totalPoints || reputation?.totalPoints || 0}</span>
+                                                <span className="text-4xl font-light font-display text-foreground tracking-tight group-hover:text-amber-500 transition-colors">{reputation?.totalPoints ?? user.totalPoints ?? 0}</span>
                                                 <span className="text-sm font-medium text-muted-foreground flex items-center gap-1 relative">
                                                     XP
                                                     <Sparkles size={14} className="text-amber-500 opacity-0 -translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all absolute -right-5" />

--- a/src/features/settings/pages/Settings.tsx
+++ b/src/features/settings/pages/Settings.tsx
@@ -36,10 +36,23 @@ export default function Settings() {
     const [reduceMotion, setReduceMotion] = useState(false);
     const [compactMode, setCompactMode] = useState(false);
 
+    // Race guards: `dirtyRef` flips when the user touches a control, `hydrated`
+    // when the initial load settles. Hydration must not clobber an edit made
+    // while the request was in flight, and no PATCH may fire pre-hydration
+    // (it would write default values over the user's stored settings).
+    const dirtyRef = useRef(false);
+    const [hydrated, setHydrated] = useState(false);
+
+    /** Wraps a state setter so user-driven changes mark the form dirty. */
+    function touch<T>(setter: (v: T) => void) {
+        return (v: T) => { dirtyRef.current = true; setter(v); };
+    }
+
     // Load from API once on mount; fall back to localStorage if the request fails.
     useEffect(() => {
         getSettings()
             .then(s => {
+                if (dirtyRef.current) return; // user already edited — don't clobber
                 setLanguage(s.language);
                 setDefaultMajor(s.defaultMajorId ?? "none");
                 setDefaultYear(s.defaultYearId != null ? String(s.defaultYearId) : "none");
@@ -48,6 +61,7 @@ export default function Settings() {
                 setCompactMode(s.compactMode);
             })
             .catch(() => {
+                if (dirtyRef.current) return;
                 // Offline / not logged in — keep localStorage defaults
                 setLanguage(localStorage.getItem("language") || "en");
                 setDefaultMajor(localStorage.getItem("geekshub-default-major") || "none");
@@ -58,16 +72,19 @@ export default function Settings() {
                 } catch { /* ignore */ }
                 setReduceMotion(localStorage.getItem("geekshub-reduce-motion") === "true");
                 setCompactMode(localStorage.getItem("geekshub-compact-mode") === "true");
-            });
+            })
+            .finally(() => setHydrated(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // Debounced API sync — fires 600 ms after the last change.
+    // Debounced API sync — fires 600 ms after the last change. Only saves once
+    // hydrated (so a pre-load PATCH can't overwrite stored settings) and only
+    // when the user actually changed something (hydration itself never echoes
+    // the loaded values back to the server).
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const isFirstRender = useRef(true);
 
     useEffect(() => {
-        if (isFirstRender.current) { isFirstRender.current = false; return; }
+        if (!hydrated || !dirtyRef.current) return;
 
         const patch: SettingsPatch = {
             language,
@@ -83,7 +100,7 @@ export default function Settings() {
         debounceRef.current = setTimeout(() => updateSettings(patch).catch(() => {}), 600);
 
         return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-    }, [language, defaultMajor, defaultYear, notifications, reduceMotion, compactMode]);
+    }, [hydrated, language, defaultMajor, defaultYear, notifications, reduceMotion, compactMode]);
 
     // Apply CSS classes when toggles change
     useEffect(() => {
@@ -217,7 +234,7 @@ export default function Settings() {
                         </div>
                         <div className="flex items-center gap-3">
                             <Globe className="h-4 w-4 text-muted-foreground" />
-                            <Select value={language} onValueChange={setLanguage}>
+                            <Select value={language} onValueChange={touch(setLanguage)}>
                                 <SelectTrigger aria-label="Language selection" className="w-[180px] liquid-glass-subtle text-foreground h-10 [&>span]:text-[13px]">
                                     <SelectValue placeholder="Select Language" />
                                 </SelectTrigger>
@@ -241,13 +258,13 @@ export default function Settings() {
                         label="Compact Mode"
                         desc="Reduce spacing to show more content on screen."
                         checked={compactMode}
-                        onCheckedChange={setCompactMode}
+                        onCheckedChange={touch(setCompactMode)}
                     />
                     <GlassToggle
                         label="Reduce Motion"
                         desc="Minimize animations across the app."
                         checked={reduceMotion}
-                        onCheckedChange={setReduceMotion}
+                        onCheckedChange={touch(setReduceMotion)}
                     />
                 </GlassSection>
 
@@ -258,8 +275,8 @@ export default function Settings() {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <GlassSelect 
                             label="Default Major" 
-                            value={defaultMajor} 
-                            onValueChange={setDefaultMajor}
+                            value={defaultMajor}
+                            onValueChange={touch(setDefaultMajor)}
                             displayValue={majors.find(m => m.id === defaultMajor)?.name || (defaultMajor === "none" ? "None" : "Loading...")}
                         >
                             <SelectItem value="none">None</SelectItem>
@@ -267,8 +284,8 @@ export default function Settings() {
                         </GlassSelect>
                         <GlassSelect 
                             label="Default Year" 
-                            value={defaultYear} 
-                            onValueChange={setDefaultYear}
+                            value={defaultYear}
+                            onValueChange={touch(setDefaultYear)}
                             displayValue={years.find(y => y.id.toString() === defaultYear)?.label || (defaultYear === "none" ? "None" : "Loading...")}
                         >
                             <SelectItem value="none">None</SelectItem>
@@ -283,13 +300,13 @@ export default function Settings() {
                         label="New Materials"
                         desc="Notify when files are added to my courses."
                         checked={notifications.newMaterials}
-                        onCheckedChange={(v: boolean) => setNotifications(prev => ({ ...prev, newMaterials: v }))}
+                        onCheckedChange={touch((v: boolean) => setNotifications(prev => ({ ...prev, newMaterials: v })))}
                     />
                     <GlassToggle
                         label="Request Updates"
                         desc="Notify status changes for my uploads."
                         checked={notifications.adminUpdates}
-                        onCheckedChange={(v: boolean) => setNotifications(prev => ({ ...prev, adminUpdates: v }))}
+                        onCheckedChange={touch((v: boolean) => setNotifications(prev => ({ ...prev, adminUpdates: v })))}
                     />
                 </GlassSection>
 

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -7,14 +7,13 @@
  * Provides:
  *   - Typed responses via generics
  *   - Automatic JSON content-type headers
- *   - Token injection from localStorage (until HTTP-only cookies are ready)
  *   - Typed error handling via ApiError class
- *   - credentials: "include" for cookie-based auth (future)
+ *   - credentials: "include" so the HttpOnly auth_token cookie rides along
  *   - Automatic snake_case → camelCase key conversion on responses
  *
- * @backend When HTTP-only cookies are implemented, remove the
- *          Authorization header logic — the browser will send cookies
- *          automatically via credentials: "include".
+ * Auth is cookie-based: the backend sets an HttpOnly auth_token cookie on
+ * signin. No token ever touches JS — localStorage/sessionStorage only cache
+ * the user profile object (SESSION_KEY) for instant boot.
  * ============================================================================
  */
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,2 +1,21 @@
+import type { RejectReason } from "@/types/domain";
+
 /** Key used to persist the authenticated user session in localStorage */
 export const SESSION_KEY = "gh_user_session";
+
+/** Human-readable labels for RejectReason enum values. */
+export const REJECT_REASON_LABELS: Record<RejectReason, string> = {
+    DUPLICATE: "Duplicate content",
+    OUTDATED: "Outdated material",
+    INCORRECT_COURSE: "Incorrect course/category",
+    BAD_QUALITY: "Poor quality",
+    OTHER: "Other reason",
+};
+
+/**
+ * Maps a rejection reason enum value to its display label.
+ * Unknown values (e.g. free-text notes from older records) pass through as-is.
+ */
+export function rejectReasonLabel(reason: string): string {
+    return REJECT_REASON_LABELS[reason as RejectReason] ?? reason;
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,6 +1,11 @@
 export const queryKeys = {
     tasks:    { all: () => ["my-tasks"] as const },
     myFiles:  { all: () => ["my-files"] as const, recent: () => ["recent-files"] as const },
+    files:    {
+        list:            (f?: object) => ["files", f] as const,
+        detail:          (id?: string) => ["file", id] as const,
+        topContributors: () => ["top-contributors"] as const,
+    },
     requests: {
         mine:     () => ["my-requests"] as const,
         all:      () => ["admin-requests"] as const,
@@ -10,15 +15,30 @@ export const queryKeys = {
     },
     catalog:  {
         majors:    () => ["majors"] as const,
+        years:     (majorId?: string) => ["years", majorId] as const,
+        semesters: (majorId?: string) => ["semesters", majorId] as const,
         courses:   (f?: object) => ["courses", f] as const,
+        course:    (id?: string) => ["course", id] as const,
         lecturers: (f?: object) => ["lecturers", f] as const,
         types:     () => ["material-types"] as const,
     },
-    audit:      { all: () => ["audit-logs"] as const },
-    reputation: { mine: () => ["my-reputation"] as const },
+    pinnedCourses: { all: () => ["pinned-courses"] as const },
+    audit:      {
+        all:      () => ["audit-logs"] as const,
+        filtered: (f?: object) => ["audit-logs", f] as const,
+    },
+    reputation: {
+        mine: () => ["my-reputation"] as const,
+        user: (userId?: string) => ["reputation", userId] as const,
+    },
     activity:   { summary: () => ["activity-summary"] as const },
+    notifications: {
+        list:        () => ["notifications"] as const,
+        unreadCount: () => ["notifications-unread-count"] as const,
+    },
     directory:  {
         stats:           () => ["directory", "stats"] as const,
+        usersRoot:       () => ["directory", "users"] as const, // prefix for invalidating all filtered lists
         users:           (f?: object) => ["directory", "users", f ?? {}] as const,
         majors:          () => ["directory", "majors"] as const,
         lecturers:       () => ["directory", "lecturers"] as const,

--- a/src/shared/hooks/useInAppNotifications.ts
+++ b/src/shared/hooks/useInAppNotifications.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/apiClient";
+import { queryKeys } from "@/lib/queryKeys";
 
 export type InAppNotification = {
     id: string;
@@ -29,12 +30,12 @@ export function useInAppNotifications() {
     const qc = useQueryClient();
 
     const { data: notifications = [] } = useQuery({
-        queryKey: ["notifications"],
+        queryKey: queryKeys.notifications.list(),
         queryFn: fetchNotifications,
     });
 
     const { data: unreadData } = useQuery({
-        queryKey: ["notifications-unread-count"],
+        queryKey: queryKeys.notifications.unreadCount(),
         queryFn: fetchUnreadCount,
         refetchInterval: 30_000,
     });
@@ -42,16 +43,16 @@ export function useInAppNotifications() {
     const { mutate: markAsRead } = useMutation({
         mutationFn: patchRead,
         onSuccess: () => {
-            qc.invalidateQueries({ queryKey: ["notifications"] });
-            qc.invalidateQueries({ queryKey: ["notifications-unread-count"] });
+            qc.invalidateQueries({ queryKey: queryKeys.notifications.list() });
+            qc.invalidateQueries({ queryKey: queryKeys.notifications.unreadCount() });
         },
     });
 
     const { mutate: markAllAsRead } = useMutation({
         mutationFn: patchReadAll,
         onSuccess: () => {
-            qc.invalidateQueries({ queryKey: ["notifications"] });
-            qc.invalidateQueries({ queryKey: ["notifications-unread-count"] });
+            qc.invalidateQueries({ queryKey: queryKeys.notifications.list() });
+            qc.invalidateQueries({ queryKey: queryKeys.notifications.unreadCount() });
         },
     });
 


### PR DESCRIPTION
## Summary

Executes the top three items from the architecture-priority review, plus cascade user deletion.

### 1. Auth leftovers (the cookie migration was already ~done; this closes the gaps)
- **`rememberMe` was silently dropped** — `authService.signIn` never sent `remember_me`, so the backend's 30-day cookie branch could never trigger. Now forwarded.
- **Production signout likely broken** — the signin cookie is `SameSite=None; Secure` in prod, but `delete_cookie("auth_token")` used default flags; browsers reject the mismatched deletion Set-Cookie in cross-site contexts, leaving the user logged in. Deletion flags now mirror the signin flags.
- Refreshed stale `apiClient.ts` docs that still described localStorage token injection.

### 2. Known open bugs
- **Raw `RejectReason` enums shown to users** (`INCORRECT_COURSE` etc.) in RequestDetailSheet and the uploader's own file list in Courses. Added shared `REJECT_REASON_LABELS` / `rejectReasonLabel()` in `lib/constants.ts`; RejectDialog options now derive from the same map.
- **Settings load-race clobber** — an edit made while the initial `getSettings()` was in flight got overwritten when it resolved, and a pre-hydration PATCH could write defaults over stored settings. Replaced the `isFirstRender` guard with a dirty-ref + hydrated gate.
- **UserProfile stale XP** — `user.totalPoints || reputation?.totalPoints` let a stale cached value beat a live zero; now `reputation?.totalPoints ?? user.totalPoints ?? 0`.
- `Recent.tsx` `file.type` (from the Jun 25 review) was already fixed on main — no change needed.

### 3. Query-key consolidation
Extended `src/lib/queryKeys.ts` with the missing domains and migrated all nine hooks still using inline literals. **Key values are unchanged**, so cache identity and invalidation behavior are preserved; no inline `queryKey` literals remain outside the registry.

### 4. Cascade user deletion
`DELETE /directory/users/{id}` previously 409'd if the user had *any* related rows. It now purges everything the user owns in one transaction — materials (incl. RAG chunks and any user's recents/notes/viewing sessions on them), file requests, points, sessions, activity, notes, notifications, pins, settings, tasks, material requests, audit entries — then deletes the GCS blobs best-effort after commit (same pattern as withdraw/reject).

Design choices worth reviewing:
- **Other users' data is detached, not deleted**: their `PointsTransaction.request_id` and `MaterialRequest.fulfilled_by_request_id` pointers to the deleted uploads are set to NULL so nobody else loses XP or fulfillment status.
- **Audit logs authored by the deleted user are removed** (the `actor_id` FK is non-nullable). If retaining moderator audit trails matters, the alternative is a schema migration to a nullable `actor_id` — happy to do that instead.
- The UsersPage confirmation dialog now warns that uploads and history are removed.

## Verification
- `tsc --noEmit`: clean
- `vitest run`: 35 passed, 1 failed — `RequestFileModal.test.tsx` timeout, **pre-existing on main** (reproduced on an untouched checkout)
- Backend: `pytest` requires a live Postgres (all failures are connection errors in this environment); `auth.py` / `directory.py` compile-checked. Manual checks recommended on a deployed build: prod signout, and deleting a user who has approved uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)