### PR TITLE
fix(ui): match table cards to platform card color in light mode

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -127,7 +127,7 @@ export function DataTable<TData, TValue>({
             )}
 
             {/* Table */}
-            <div className="rounded-md border border-border bg-black/20">
+            <div className="rounded-md border border-border bg-card">
                 <Table>
                     <TableHeader>
                         {table.getHeaderGroups().map((headerGroup) => (

--- a/src/features/admin/pages/AuditLog.tsx
+++ b/src/features/admin/pages/AuditLog.tsx
@@ -90,7 +90,7 @@ export default function AuditLog() {
                             </p>
                         </div>
                     ) : (
-                        <div className="rounded-md border border-border bg-black/20">
+                        <div className="rounded-md border border-border bg-card">
                             <Table>
                                 <TableHeader>
                                     <TableRow>


### PR DESCRIPTION
## Summary
- The `DataTable` wrapper (Users page, Moderation Queue) and the Audit Log table used a hardcoded `bg-black/20`, which renders as an off-grey card in light mode.
- Swapped to the `bg-card` theme token, matching every other card on the platform: white in light mode, deep navy (`225 25% 8%`) in dark mode — visually near-identical to the old translucent black over the navy background.
- Left `RequestDetailSheet`'s `bg-black/20` untouched: that's a file-preview box, not a card.

## Testing
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)