### PR TITLE
fix(settings): remove unused Sparkles import breaking the build

### DIFF
--- a/src/features/settings/pages/Settings.tsx
+++ b/src/features/settings/pages/Settings.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef } from "react";
-import { Monitor, Globe, CheckCircle, Sun, Moon, Laptop, Palette, Sparkles, BookOpen, Bell } from "lucide-react";
+import { Monitor, Globe, CheckCircle, Sun, Moon, Laptop, Palette, BookOpen, Bell } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useTheme } from "@/shared/hooks/useTheme";


### PR DESCRIPTION
## Summary
- `ad0afe4` ("polish") removed the `Sparkles` usage in Settings.tsx but left the import, so `npm run build` fails with TS6133 (`noUnusedLocals`). main currently does not build.
- One-line fix: drop `Sparkles` from the lucide-react import.

## Testing
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)