### PR TITLE
feat(rbac): invert role hierarchy — MODERATOR above ADMIN

### DIFF
--- a/server/routers/directory.py
+++ b/server/routers/directory.py
@@ -1,9 +1,11 @@
 """
 Directory management.
 
-Exposes /api/v1/directory/* for MODERATOR (and ADMIN) users to manage the platform
-directory: users, lecturers, courses, and lecturer<->course assignments. Reuses the
-existing CourseLecturer junction model — no new table.
+Exposes /api/v1/directory/*. Role hierarchy: STUDENT < ADMIN < MODERATOR.
+- /stats and /users/* are MODERATOR-only (user management is moderator work).
+- Majors, lecturers, courses, and lecturer<->course assignments are ADMIN-level
+  (moderators inherit admin privileges). Reuses the existing CourseLecturer
+  junction model — no new table.
 """
 
 import re
@@ -49,7 +51,7 @@ from schemas import (
     MajorCreate,
     MajorUpdate,
 )
-from utils.auth_utils import get_moderator_user
+from utils.auth_utils import get_admin_user, get_moderator_user
 
 router = APIRouter(prefix="/api/v1/directory", tags=["Directory"])
 
@@ -139,12 +141,10 @@ def update_user(
     if not user:
         raise HTTPException(status_code=404, detail="User not found.")
 
-    # Only ADMINs may grant the ADMIN role or modify an existing admin.
-    if mod.role != "ADMIN":
-        if payload.role == "ADMIN":
-            raise HTTPException(status_code=403, detail="Only an admin can grant the ADMIN role.")
-        if user.role == "ADMIN":
-            raise HTTPException(status_code=403, detail="Only an admin can modify another admin.")
+    # A moderator may not change their own role — prevents accidentally
+    # demoting the last moderator and locking user management.
+    if user.id == mod.id and payload.role is not None and payload.role != user.role:
+        raise HTTPException(status_code=400, detail="You cannot change your own role.")
 
     if payload.name is not None:
         user.name = payload.name
@@ -250,8 +250,6 @@ def delete_user(
         raise HTTPException(status_code=404, detail="User not found.")
     if user.id == mod.id:
         raise HTTPException(status_code=400, detail="You cannot delete your own account.")
-    if user.role == "ADMIN" and mod.role != "ADMIN":
-        raise HTTPException(status_code=403, detail="Only an admin can delete an admin.")
 
     try:
         blob_paths = _purge_user_data(session, user)
@@ -289,7 +287,7 @@ def delete_user(
 @router.get("/majors")
 def list_majors(
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     """All majors with how many courses each contains."""
     rows = session.exec(
@@ -308,7 +306,7 @@ def list_majors(
 def create_major(
     payload: MajorCreate,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     name = payload.name.strip()
     slug = slugify(name)
@@ -329,7 +327,7 @@ def update_major(
     major_id: UUID,
     payload: MajorUpdate,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     major = session.get(Major, major_id)
     if not major:
@@ -356,7 +354,7 @@ def update_major(
 def delete_major(
     major_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     major = session.get(Major, major_id)
     if not major:
@@ -380,7 +378,7 @@ def delete_major(
 @router.get("/lecturers")
 def list_lecturers(
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     """All lecturers with how many courses each is assigned to."""
     try:
@@ -403,7 +401,7 @@ def list_lecturers(
 def create_lecturer(
     payload: LecturerCreate,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     if session.exec(select(Lecturer).where(Lecturer.name == payload.name)).first():
         raise HTTPException(status_code=409, detail="A lecturer with that name already exists.")
@@ -419,7 +417,7 @@ def update_lecturer(
     lecturer_id: UUID,
     payload: LecturerUpdate,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     lecturer = session.get(Lecturer, lecturer_id)
     if not lecturer:
@@ -440,7 +438,7 @@ def update_lecturer(
 def delete_lecturer(
     lecturer_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     lecturer = session.get(Lecturer, lecturer_id)
     if not lecturer:
@@ -472,7 +470,7 @@ def delete_lecturer(
 def list_lecturer_courses(
     lecturer_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     if not session.get(Lecturer, lecturer_id):
         raise HTTPException(status_code=404, detail="Lecturer not found.")
@@ -489,7 +487,7 @@ def assign_course(
     lecturer_id: UUID,
     course_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     if not session.get(Lecturer, lecturer_id):
         raise HTTPException(status_code=404, detail="Lecturer not found.")
@@ -507,7 +505,7 @@ def unassign_course(
     lecturer_id: UUID,
     course_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     row = session.get(CourseLecturer, (course_id, lecturer_id))
     if not row:
@@ -525,7 +523,7 @@ def unassign_course(
 def create_course(
     payload: CourseCreate,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     if not session.get(Major, payload.majorId):
         raise HTTPException(status_code=400, detail="Major not found.")
@@ -549,7 +547,7 @@ def update_course(
     course_id: UUID,
     payload: CourseUpdate,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     course = session.get(Course, course_id)
     if not course:
@@ -580,7 +578,7 @@ def update_course(
 def delete_course(
     course_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     course = session.get(Course, course_id)
     if not course:
@@ -608,7 +606,7 @@ def delete_course(
 def list_course_lecturers(
     course_id: UUID,
     session: Session = Depends(get_session),
-    mod: User = Depends(get_moderator_user),
+    mod: User = Depends(get_admin_user),
 ):
     if not session.get(Course, course_id):
         raise HTTPException(status_code=404, detail="Course not found.")

--- a/server/tests/test_p1_rbac.py
+++ b/server/tests/test_p1_rbac.py
@@ -1,8 +1,12 @@
 """STD Module: RBAC — RBAC-001..003.
 
-Note: the STD expects "Admin privileges required" from /directory/* — the code
-actually gates directory behind get_moderator_user ("Moderator privileges
-required."). Still a 403 for students; the message deviation is recorded in the STR.
+Role hierarchy: STUDENT < ADMIN < MODERATOR. Moderators inherit all admin
+privileges (moderation queue, audit, lecturers/courses/majors); user management
+(/directory/users, /directory/stats) is MODERATOR-only — admins are rejected.
+
+Note: the STD expects "Admin privileges required" from /directory/users — the code
+actually gates it behind get_moderator_user ("Moderator privileges required.").
+Still a 403 for students; the message deviation is recorded in the STR.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -35,16 +39,32 @@ def test_rbac_001_student_blocked_from_privileged_endpoints(client, seed, as_use
     assert r.status_code == 403
 
 
-# --- RBAC-002 (P1) — moderator passes moderator gate, fails admin gate ---
-def test_rbac_002_moderator_allowed_moderator_blocked_admin(client, seed, as_user):
+# --- RBAC-002 (P1) — moderator is the top role; admin blocked from user management ---
+def test_rbac_002_moderator_top_admin_blocked_from_user_management(client, seed, as_user):
+    # Moderator passes both gates (inherits admin privileges).
     as_user(seed.moderator_id)
 
     r_mod = client.get("/api/v1/directory/users")
     assert r_mod.status_code == 200, r_mod.text
 
     r_admin = client.get("/api/v1/admin/requests")
-    assert r_admin.status_code == 403
-    assert "Admin privileges required" in r_admin.json()["detail"]
+    assert r_admin.status_code == 200, r_admin.text
+
+    # Admin keeps admin jobs but is rejected from moderator-only user management.
+    as_user(seed.admin_id)
+
+    r_admin = client.get("/api/v1/admin/requests")
+    assert r_admin.status_code == 200, r_admin.text
+
+    r_users = client.get("/api/v1/directory/users")
+    assert r_users.status_code == 403
+    assert r_users.json()["detail"] == "Moderator privileges required."
+
+    r_update = client.put(f"/api/v1/directory/users/{seed.student_a_id}", json={"name": "X"})
+    assert r_update.status_code == 403
+
+    r_delete = client.delete(f"/api/v1/directory/users/{seed.student_a_id}")
+    assert r_delete.status_code == 403
 
 
 # --- RBAC-003 (P1) — role injection in signup is ignored ---

--- a/server/utils/auth_utils.py
+++ b/server/utils/auth_utils.py
@@ -67,12 +67,13 @@ def get_verified_user(request: Request,
         raise HTTPException(status_code=401, detail="Authentication failed.")
     
 def get_admin_user(current_user: User = Depends(get_verified_user)):
-    if current_user.role != "ADMIN":
+    """Admin-level gate. Hierarchy: STUDENT < ADMIN < MODERATOR — moderators inherit admin privileges."""
+    if current_user.role not in ("ADMIN", "MODERATOR"):
         raise HTTPException(status_code=403, detail=f"Admin privileges required. Your role: {current_user.role}")
     return current_user
 
 def get_moderator_user(current_user: User = Depends(get_verified_user)):
-    """Allows both MODERATOR and ADMIN — admins inherit moderator privileges."""
-    if current_user.role not in ("ADMIN", "MODERATOR"):
+    """Moderator-only gate — the top role. Admins are NOT allowed."""
+    if current_user.role != "MODERATOR":
         raise HTTPException(status_code=403, detail="Moderator privileges required.")
     return current_user

--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -20,8 +20,10 @@
  *    GET /api/v1/me/notifications/unread-count ? { count: number }
  *    Poll every 30s. Wire into the Bell button when endpoint is ready.
  *
- * 3. Conditional Admin Link:
- *    Admin nav item is shown only when user.role === "ADMIN".
+ * 3. Conditional Admin/Moderator Links:
+ *    Hierarchy: STUDENT < ADMIN < MODERATOR. The Admin nav item is shown to
+ *    ADMIN and MODERATOR (moderators inherit admin); the Moderator nav item
+ *    is shown to MODERATOR only.
  *
  * 4. Language preference:
  *    Currently reads from localStorage. After Settings backend is connected,
@@ -146,8 +148,8 @@ function GlassSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: (
         ? user.displayName.split(" ").map((n: string) => n[0]).join("").toUpperCase().slice(0, 2)
         : "?";
 
-    const isAdmin = user?.role === "ADMIN";
-    const isModerator = user?.role === "MODERATOR" || isAdmin;
+    const isModerator = user?.role === "MODERATOR";
+    const isAdmin = user?.role === "ADMIN" || isModerator;
 
     return (
         <TooltipProvider delayDuration={0}>
@@ -244,7 +246,7 @@ function GlassSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: (
                             return linkContent;
                         })}
 
-                        {/* Admin link only shown to admins */}
+                        {/* Admin link shown to admins and moderators */}
                         {isAdmin && (() => {
                             const adminLink = (
                                 <Link
@@ -274,7 +276,7 @@ function GlassSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: (
                             return adminLink;
                         })()}
 
-                        {/* Moderator link shown to moderators and admins */}
+                        {/* Moderator link shown to moderators only */}
                         {isModerator && (() => {
                             const moderatorLink = (
                                 <Link

--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -139,7 +139,7 @@ export const router = createBrowserRouter([
     // Protected admin routes
     {
         path: "/admin",
-        element: <ProtectedRoute requiredRoles={["ADMIN"]} />,
+        element: <ProtectedRoute requiredRoles={["ADMIN", "MODERATOR"]} />,
         errorElement: <RouteError name="Admin Auth" />,
         children: [
             {
@@ -178,7 +178,7 @@ export const router = createBrowserRouter([
     // Protected moderator routes
     {
         path: "/moderator",
-        element: <ProtectedRoute requiredRoles={["ADMIN", "MODERATOR"]} />,
+        element: <ProtectedRoute requiredRoles={["MODERATOR"]} />,
         errorElement: <RouteError name="Moderator Auth" />,
         children: [
             {

--- a/src/features/auth/context/AuthContext.tsx
+++ b/src/features/auth/context/AuthContext.tsx
@@ -163,7 +163,14 @@ export function useAuth(): AuthContextValue {
     return ctx;
 }
 
+/** Admin-level privileges. Hierarchy: STUDENT < ADMIN < MODERATOR — moderators inherit admin. */
 export function useIsAdmin(): boolean {
     const { user } = useAuth();
-    return user?.role === "ADMIN";
+    return user?.role === "ADMIN" || user?.role === "MODERATOR";
+}
+
+/** Moderator-only privileges (the top role). */
+export function useIsModerator(): boolean {
+    const { user } = useAuth();
+    return user?.role === "MODERATOR";
 }

--- a/src/features/directory/api/directoryService.ts
+++ b/src/features/directory/api/directoryService.ts
@@ -5,8 +5,10 @@
  *
  * API calls for managing the platform directory — users, lecturers, courses,
  * and lecturer↔course assignment. Used by both the moderator (Users) and admin
- * (Lecturers, Courses) sections; the backend gates `/directory/*` to ADMIN and
- * MODERATOR roles. Request bodies are camelCase; responses are auto-camelCased.
+ * (Lecturers, Courses) sections. Hierarchy: STUDENT < ADMIN < MODERATOR — the
+ * backend gates `/directory/users` and `/directory/stats` to MODERATOR only,
+ * while majors/lecturers/courses are ADMIN-level (moderators inherit).
+ * Request bodies are camelCase; responses are auto-camelCased.
  * ============================================================================
  */
 

--- a/src/shared/components/CommandPalette.tsx
+++ b/src/shared/components/CommandPalette.tsx
@@ -19,6 +19,7 @@ import {
     Settings,
     LogOut,
     Shield,
+    ShieldCheck,
     FileText
 } from "lucide-react"
 
@@ -96,10 +97,16 @@ export function CommandPalette() {
                 <CommandSeparator />
 
                 <CommandGroup heading="Account">
-                    {user?.role === "ADMIN" && (
+                    {(user?.role === "ADMIN" || user?.role === "MODERATOR") && (
                         <CommandItem onSelect={() => runCommand(() => navigate("/admin"))}>
                             <Shield className="mr-2 h-4 w-4" />
                             Admin Dashboard
+                        </CommandItem>
+                    )}
+                    {user?.role === "MODERATOR" && (
+                        <CommandItem onSelect={() => runCommand(() => navigate("/moderator"))}>
+                            <ShieldCheck className="mr-2 h-4 w-4" />
+                            Moderator Dashboard
                         </CommandItem>
                     )}
                     <CommandItem onSelect={() => runCommand(() => signOut())}>

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -55,7 +55,7 @@
 // ENUMS / UNION TYPES
 // ============================================================================
 
-/** User roles for authorization */
+/** User roles for authorization. Hierarchy: STUDENT < ADMIN < MODERATOR (moderators inherit admin privileges). */
 export type Role = "STUDENT" | "ADMIN" | "MODERATOR";
 
 /** Status of a file or file request */


### PR DESCRIPTION
## Summary
Inverts the role hierarchy to **STUDENT < ADMIN < MODERATOR**: moderators can now do everything admins can, while admins can no longer access moderator-only user management.

### Backend
- `get_admin_user` now admits ADMIN **or** MODERATOR (moderators inherit admin); `get_moderator_user` admits MODERATOR **only**. 403 detail strings unchanged, so `test_rbac_001` passes untouched.
- `directory.py`: majors/lecturers/courses/lecturer-course-link endpoints moved to the admin-level gate; `/users` (GET/PUT/DELETE) and `/stats` stay on the strict moderator gate.
- Deleted the obsolete "only an admin can grant ADMIN / modify an admin / delete an admin" intra-route checks (only moderators — the top role — can reach those endpoints now). Added a guard so a moderator cannot change **their own** role (prevents locking out the last moderator; self-delete guard kept).
- `admin.py` (moderation queue, audit logs) needed zero changes — all 11 endpoints keep `get_admin_user`, which now admits moderators.
- `test_rbac_002` inverted: moderator gets 200 on both `/admin/requests` and `/directory/users`; admin gets 200 on `/admin/requests` but 403 on `/directory/users` (GET/PUT/DELETE).

### Frontend
- `/admin` route guard: `["ADMIN", "MODERATOR"]`; `/moderator` route guard: `["MODERATOR"]`.
- AppShell sidebar: moderators see both Admin and Moderator links; admins see only the Admin link.
- `useIsAdmin()` now includes moderators; added `useIsModerator()`.
- CommandPalette: Admin Dashboard command shown to both roles; new Moderator Dashboard command for moderators.
- Docstring/comment updates in `directoryService.ts`, `domain.ts`, `AppShell.tsx`.

## Verification
- `npx tsc --noEmit` — clean.
- `npx vitest run` — 35/36 pass; the one failure is `RequestFileModal.test.tsx`, known-failing on main (pre-existing, unrelated).
- Backend modules compile (`py_compile`); pytest requires a live Postgres, so the inverted `test_p1_rbac.py` should be exercised in CI.
- Manual checks to do before merge: sign in as MODERATOR (both dashboards work, incl. moderation queue), as ADMIN (`/moderator` redirects, `GET /api/v1/directory/users` → 403), as STUDENT (no privileged access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)