### PR TITLE
Platform-wide user-friendly error system

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -9,12 +9,15 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
+import logging
+import traceback
 from pathlib import Path
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI, Depends, Request
+from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from sqlmodel import Session, select
 from contextlib import asynccontextmanager
@@ -51,6 +54,30 @@ app = FastAPI(title="GeeksHub API", lifespan=lifespan)
 # @limiter.limit decorator surfaces as an unstyled error instead of a clean 429.
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+logger = logging.getLogger("geekshub")
+
+
+# Catch-all safety net: any exception a route forgot to handle would otherwise
+# bubble up as a bare 500. We log the full traceback server-side (for us) and
+# return a calm, generic message to the user — never the raw exception, SQL,
+# or stack trace. Handlers registered for HTTPException / RequestValidationError
+# still run first, so intentional 4xx responses keep their specific messages.
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.error(
+        "Unhandled error on %s %s: %s\n%s",
+        request.method,
+        request.url.path,
+        exc,
+        "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    )
+    return JSONResponse(
+        status_code=500,
+        content={
+            "detail": "Something went wrong on our end. This is on us — please try again in a moment.",
+        },
+    )
 
 app.add_middleware(SecurityHeadersMiddleware)
 

--- a/server/routers/admin.py
+++ b/server/routers/admin.py
@@ -139,7 +139,8 @@ def approve_file(
             final_gcs_path = f"{safe_course_name}/{filename}"
             bucket.rename_blob(bucket.blob(request.file_url), final_gcs_path)
     except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=f"PPTX conversion failed: {e}")
+        print(f"PPTX conversion failed: {e}")
+        raise HTTPException(status_code=500, detail="We couldn't process that presentation file. Please try uploading it again, or convert it to PDF first.")
     except Exception as e:
         print(f"GCS Move failed: {e}")
         raise HTTPException(status_code=500, detail="Cloud storage error.")

--- a/server/routers/directory.py
+++ b/server/routers/directory.py
@@ -394,7 +394,7 @@ def list_lecturers(
         ]
     except Exception as e:
         print("Error fetching lecturers:", e)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="We couldn't load the lecturers right now. Please try again.")
 
 
 @router.post("/lecturers", status_code=201)

--- a/server/utils/auth_utils.py
+++ b/server/utils/auth_utils.py
@@ -69,7 +69,7 @@ def get_verified_user(request: Request,
 def get_admin_user(current_user: User = Depends(get_verified_user)):
     """Admin-level gate. Hierarchy: STUDENT < ADMIN < MODERATOR — moderators inherit admin privileges."""
     if current_user.role not in ("ADMIN", "MODERATOR"):
-        raise HTTPException(status_code=403, detail=f"Admin privileges required. Your role: {current_user.role}")
+        raise HTTPException(status_code=403, detail="You don't have permission to do this. Admin access is required.")
     return current_user
 
 def get_moderator_user(current_user: User = Depends(get_verified_user)):

--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -63,12 +63,12 @@ export const router = createBrowserRouter([
     // Protected app routes
     {
         element: <ProtectedRoute />,
-        errorElement: <RouteError name="Auth" />,
+        errorElement: <RouteError name="sign-in page" />,
         children: [
             {
                 path: "/",
                 element: <AppShell />,
-                errorElement: <RouteError name="AppShell" />,
+                errorElement: <RouteError name="page" />,
                 children: [
                     {
                         index: true,
@@ -100,7 +100,7 @@ export const router = createBrowserRouter([
                             {
                                 path: ":courseId",
                                 element: <CourseShell />,
-                                errorElement: <RouteError name="CourseShell" />,
+                                errorElement: <RouteError name="course" />,
                                 children: [
                                     {
                                         index: true,
@@ -140,12 +140,12 @@ export const router = createBrowserRouter([
     {
         path: "/admin",
         element: <ProtectedRoute requiredRoles={["ADMIN", "MODERATOR"]} />,
-        errorElement: <RouteError name="Admin Auth" />,
+        errorElement: <RouteError name="admin area" />,
         children: [
             {
                 path: "",
                 element: <AdminShell />,
-                errorElement: <RouteError name="Admin" />,
+                errorElement: <RouteError name="admin area" />,
                 children: [
                     {
                         index: true,
@@ -179,12 +179,12 @@ export const router = createBrowserRouter([
     {
         path: "/moderator",
         element: <ProtectedRoute requiredRoles={["MODERATOR"]} />,
-        errorElement: <RouteError name="Moderator Auth" />,
+        errorElement: <RouteError name="moderator area" />,
         children: [
             {
                 path: "",
                 element: <ModeratorShell />,
-                errorElement: <RouteError name="Moderator" />,
+                errorElement: <RouteError name="moderator area" />,
                 children: [
                     {
                         index: true,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,6 +9,9 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         className={cn(
           "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          // Accessible invalid state: red border + ring so it never relies on
+          // color alone (pair with <FieldError> for the icon + text).
+          "aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus-visible:ring-red-500",
           className
         )}
         ref={ref}

--- a/src/features/auth/api/authService.ts
+++ b/src/features/auth/api/authService.ts
@@ -1,10 +1,13 @@
 import { api, ApiError } from "@/lib/apiClient";
 import { logger } from "@/lib/logger";
+import { normalizeError } from "@/lib/errors";
 import type { Role } from "@/types/domain";
 
 export type AuthError = {
     message: string;
     field?: string;
+    /** field-name → message, for inline display beside the relevant input. */
+    fieldErrors?: Record<string, string>;
 };
 
 /** Shape returned by /signin after snake_case→camelCase conversion. */
@@ -104,9 +107,14 @@ export const authService = {
             return { user: data.user };
         } catch (err: unknown) {
             if (err instanceof ApiError && err.status === 403) {
-                throw { message: "Please check your email to verify your account before logging in." };
+                throw {
+                    message: "Please check your email and verify your account before signing in.",
+                } satisfies AuthError;
             }
-            throw { message: extractAuthErrorMessage(err, "Login failed") };
+            throw {
+                message: extractAuthErrorMessage(err, "We couldn't sign you in. Please try again."),
+                fieldErrors: normalizeError(err).fieldErrors,
+            } satisfies AuthError;
         }
     },
 
@@ -123,7 +131,10 @@ export const authService = {
                 }),
             });
         } catch (err: unknown) {
-            throw { message: extractAuthErrorMessage(err, "Signup failed") };
+            throw {
+                message: extractAuthErrorMessage(err, "We couldn't create your account. Please try again."),
+                fieldErrors: normalizeError(err).fieldErrors,
+            } satisfies AuthError;
         }
     },
 

--- a/src/features/auth/components/forms/ResetPasswordForm.tsx
+++ b/src/features/auth/components/forms/ResetPasswordForm.tsx
@@ -3,9 +3,10 @@ import { useSearchParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { authService } from "@/features/auth/api/authService";
+import { authService, type AuthError } from "@/features/auth/api/authService";
 import { Loader2, CheckCircle2, Lock } from "lucide-react";
 import { Link } from "react-router-dom";
+import { FieldError, FormErrorSummary } from "@/shared/components/errors";
 
 /**
  * Prefer the token from the URL fragment (#token=...) over the query string.
@@ -26,33 +27,39 @@ export default function ResetPasswordForm() {
     const [isLoading, setIsLoading] = useState(false);
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState("");
+    const [fieldErrors, setFieldErrors] = useState<{ password?: string; confirmPassword?: string }>({});
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        setIsLoading(true);
         setError("");
+        setFieldErrors({});
 
-        const formData = new FormData(e.target as HTMLFormElement);
+        const form = e.target as HTMLFormElement;
+        const formData = new FormData(form);
         const password = formData.get("password") as string;
         const confirmPassword = formData.get("confirmPassword") as string;
 
+        const errors: { password?: string; confirmPassword?: string } = {};
         if (password.length < 8) {
-            setError("Password must be at least 8 characters.");
-            setIsLoading(false);
-            return;
+            errors.password = "Your password must be at least 8 characters.";
         }
-
         if (password !== confirmPassword) {
-            setError("Passwords do not match.");
-            setIsLoading(false);
+            errors.confirmPassword = "Both passwords need to match. Re-enter them to be sure.";
+        }
+        if (Object.keys(errors).length > 0) {
+            setFieldErrors(errors);
+            const firstInvalid = errors.password ? "password" : "confirmPassword";
+            form.querySelector<HTMLInputElement>(`[name="${firstInvalid}"]`)?.focus();
             return;
         }
 
+        setIsLoading(true);
         try {
             await authService.confirmPasswordReset({ token, password });
             setSuccess(true);
-        } catch (err: any) {
-            setError(err.message || "Failed to reset password.");
+        } catch (err) {
+            const authErr = err as AuthError;
+            setError(authErr?.message || "We couldn't reset your password. The link may have expired — request a new one.");
         } finally {
             setIsLoading(false);
         }
@@ -95,7 +102,7 @@ export default function ResetPasswordForm() {
     }
 
     return (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4 animate-in fade-in duration-300 w-full max-w-sm mx-auto p-6 bg-card rounded-xl shadow-lg border">
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4 animate-in fade-in duration-300 w-full max-w-sm mx-auto p-6 bg-card rounded-xl shadow-lg border">
             <div className="text-center mb-2">
                 <h2 className="text-2xl font-bold">Reset Password</h2>
                 <p className="text-sm text-muted-foreground">Enter a new secure password</p>
@@ -112,7 +119,10 @@ export default function ResetPasswordForm() {
                         required
                         autoFocus
                         disabled={isLoading}
+                        aria-invalid={!!fieldErrors.password || undefined}
+                        aria-describedby={fieldErrors.password ? "reset-password-error" : undefined}
                     />
+                    <FieldError id="reset-password-error">{fieldErrors.password}</FieldError>
                 </div>
                 <div className="space-y-2">
                     <Label htmlFor="confirmPassword">Confirm Password</Label>
@@ -123,11 +133,14 @@ export default function ResetPasswordForm() {
                         className="h-10"
                         required
                         disabled={isLoading}
+                        aria-invalid={!!fieldErrors.confirmPassword || undefined}
+                        aria-describedby={fieldErrors.confirmPassword ? "reset-confirm-error" : undefined}
                     />
+                    <FieldError id="reset-confirm-error">{fieldErrors.confirmPassword}</FieldError>
                 </div>
             </div>
 
-            {error && <p className="text-red-500 text-xs">{error}</p>}
+            <FormErrorSummary message={error} autoFocus />
 
             <Button className="w-full mt-2" type="submit" disabled={isLoading}>
                 {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/src/features/auth/components/forms/SignInForm.tsx
+++ b/src/features/auth/components/forms/SignInForm.tsx
@@ -5,6 +5,8 @@ import { useAuth } from "@/features/auth/context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { Loader2, Eye, EyeOff } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FormErrorSummary } from "@/shared/components/errors";
+import type { AuthError } from "@/features/auth/api/authService";
 
 interface SignInFormProps {
     onForgotPassword?: () => void;
@@ -13,6 +15,7 @@ interface SignInFormProps {
 export default function SignInForm({ onForgotPassword }: SignInFormProps) {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState("");
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
     const [showPassword, setShowPassword] = useState(false);
     const [rememberMe, setRememberMe] = useState(false);
     const { signIn } = useAuth();
@@ -22,6 +25,7 @@ export default function SignInForm({ onForgotPassword }: SignInFormProps) {
         e.preventDefault();
         setIsLoading(true);
         setError("");
+        setFieldErrors({});
 
         const formData = new FormData(e.target as HTMLFormElement);
         const email = formData.get("email") as string;
@@ -30,40 +34,51 @@ export default function SignInForm({ onForgotPassword }: SignInFormProps) {
         try {
             await signIn(email, password, rememberMe);
             navigate("/");
-        } catch (err: any) {
-            setError(err.message || "An error occurred.");
+        } catch (err) {
+            const authErr = err as AuthError;
+            setError(authErr?.message || "We couldn't sign you in. Please try again.");
+            setFieldErrors(authErr?.fieldErrors ?? {});
         } finally {
             setIsLoading(false);
         }
     };
 
     return (
-        <form onSubmit={handleSubmit} className="flex flex-col items-center justify-center w-full px-8">
+        <form onSubmit={handleSubmit} className="flex flex-col items-center justify-center w-full px-8" noValidate>
 
             <div className="w-full space-y-3 mt-4">
-                <Input
-                    name="email"
-                    type="email"
-                    placeholder="Email"
-                    className="h-10"
-                    required
-                    autoFocus
-                    disabled={isLoading}
-                />
-                <div className="relative">
+                <div>
+                    <label htmlFor="signin-email" className="sr-only">Email</label>
                     <Input
+                        id="signin-email"
+                        name="email"
+                        type="email"
+                        placeholder="Email"
+                        className="h-10"
+                        required
+                        autoFocus
+                        disabled={isLoading}
+                        aria-invalid={!!fieldErrors.email || undefined}
+                    />
+                </div>
+                <div className="relative">
+                    <label htmlFor="signin-password" className="sr-only">Password</label>
+                    <Input
+                        id="signin-password"
                         name="password"
                         type={showPassword ? "text" : "password"}
                         placeholder="Password"
                         className="h-10 pr-10"
                         required
                         disabled={isLoading}
+                        aria-invalid={!!fieldErrors.password || undefined}
                     />
                     <button
                         type="button"
                         onClick={() => setShowPassword((prev) => !prev)}
                         className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                         disabled={isLoading}
+                        aria-label={showPassword ? "Hide password" : "Show password"}
                     >
                         {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                     </button>
@@ -86,19 +101,16 @@ export default function SignInForm({ onForgotPassword }: SignInFormProps) {
                 </button>
             </div>
 
-            <div>
-                <br />
-            </div>
+            <FormErrorSummary message={error} autoFocus className="w-full mt-4" />
+
             {/* Submit Button */}
             <Button
-                className="rounded-full w-full px-12 py-6 font-bold uppercase text-xs tracking-wider transition-transform active:scale-95"
+                className="rounded-full w-full px-12 py-6 mt-6 font-bold uppercase text-xs tracking-wider transition-transform active:scale-95"
                 type="submit"
                 disabled={isLoading}
             >
                 {isLoading ? <Loader2 className="animate-spin h-4 w-4" /> : "Sign In"}
             </Button>
-
-            {error && <p className="text-red-500 text-xs mt-2">{error}</p>}
         </form>
     );
 }

--- a/src/features/auth/components/forms/SignUpForm.tsx
+++ b/src/features/auth/components/forms/SignUpForm.tsx
@@ -7,10 +7,15 @@ import { Loader2, Eye, EyeOff } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useMajors } from "@/features/courses/hooks/useCatalog";
 import { toast } from "sonner";
+import { FieldError, FormErrorSummary } from "@/shared/components/errors";
+import type { AuthError } from "@/features/auth/api/authService";
+
+type FieldErrors = Partial<Record<"name" | "email" | "major" | "password" | "confirmPassword", string>>;
 
 export default function SignUpForm() {
     const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState("");
+    const [formError, setFormError] = useState("");
+    const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
     const [showPassword, setShowPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
     const [majorId, setMajorId] = useState("");
@@ -21,126 +26,170 @@ export default function SignUpForm() {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        setIsLoading(true);
-        setError("");
+        setFormError("");
 
-        const formData = new FormData(e.target as HTMLFormElement);
+        const form = e.target as HTMLFormElement;
+        const formData = new FormData(form);
         const data = Object.fromEntries(formData);
 
+        // Client-side checks — collected together so we can focus the first
+        // invalid field and show every problem at once (not one at a time).
+        const errors: FieldErrors = {};
+        const email = (data.email as string).toLowerCase().trim();
+
+        if (!email.endsWith("@post.jce.ac.il")) {
+            errors.email = "Use your Azrieli College email — it ends in @post.jce.ac.il.";
+        }
+        if ((data.password as string).length < 8) {
+            errors.password = "Your password must be at least 8 characters.";
+        }
         if (data.password !== data.confirmPassword) {
-            setError("Passwords do not match");
-            setIsLoading(false);
-            return;
+            errors.confirmPassword = "Both passwords need to match. Re-enter them to be sure.";
         }
-
-        // --- DOMAIN CHECK ---
-        const userEmail = (data.email as string).toLowerCase().trim();
-        if (!userEmail.endsWith("@post.jce.ac.il")) {
-            setError("You must use an Azrieli College email (@post.jce.ac.il) to join.");
-            setIsLoading(false);
-            return;
-        }
-
         if (!majorId) {
-            setError("Please select a major");
-            setIsLoading(false);
+            errors.major = "Choose your major to continue.";
+        }
+
+        if (Object.keys(errors).length > 0) {
+            setFieldErrors(errors);
+            // Move focus to the first field that needs attention.
+            const firstInvalid = (["name", "email", "password", "confirmPassword"] as const).find((f) => errors[f]);
+            if (firstInvalid) form.querySelector<HTMLInputElement>(`[name="${firstInvalid}"]`)?.focus();
             return;
         }
+
+        setFieldErrors({});
+        setIsLoading(true);
 
         try {
             await signUp(data.name as string, data.email as string, data.password as string, data.confirmPassword as string, majorId);
-            toast.success("Account created! 📧 Please check your email to verify before logging in.", {
-                duration: 8000, // Keep it on screen a bit longer so they read it
+            toast.success("Account created!", {
+                description: "Check your email to verify your account, then sign in.",
+                duration: 8000,
             });
-
-            // [backend update] Since we now require email verification, we won't auto-login the user after sign-up.
-            // 2. Route them to the sign-in page so they can log in AFTER verifying.
-            // (If your sliding auth page is on a specific route like "/auth", change this to that route)
             navigate("/auth");
-        } catch (err: any) {
-            setError(err.message || "An error occurred.");
+        } catch (err) {
+            const authErr = err as AuthError;
+            setFormError(authErr?.message || "We couldn't create your account. Please try again.");
+            setFieldErrors(authErr?.fieldErrors ?? {});
         } finally {
             setIsLoading(false);
         }
     };
 
     return (
-        <form onSubmit={handleSubmit} className="flex flex-col items-center justify-center w-full px-8">
+        <form onSubmit={handleSubmit} className="flex flex-col items-center justify-center w-full px-8" noValidate>
 
             <div className="w-full space-y-3 mt-4">
-                <Input
-                    name="name"
-                    type="text"
-                    placeholder="Full name"
-                    className="h-10"
-                    required
-                    autoFocus
-                    disabled={isLoading}
-                />
-                <Input
-                    name="email"
-                    type="email"
-                    placeholder="University email"
-                    className="h-10"
-                    required
-                    disabled={isLoading}
-                />
-
-                <Select value={majorId} onValueChange={setMajorId} disabled={isMajorsLoading || isMajorsError || isLoading}>
-                    <SelectTrigger className="h-10">
-                        <SelectValue placeholder={isMajorsLoading ? "Loading majors..." : isMajorsError ? "Failed to load majors" : "Select Major"}>
-                            {majors?.find((m) => m.id === majorId)?.name}
-                        </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                        {majors?.map((major) => (
-                            <SelectItem key={major.id} value={major.id}>
-                                {major.name}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-
-                <div className="relative">
+                <div>
+                    <label htmlFor="signup-name" className="sr-only">Full name</label>
                     <Input
-                        name="password"
-                        type={showPassword ? "text" : "password"}
-                        placeholder="Password"
-                        className="h-10 pr-10"
+                        id="signup-name"
+                        name="name"
+                        type="text"
+                        placeholder="Full name"
+                        className="h-10"
                         required
-                        minLength={8}
+                        autoFocus
                         disabled={isLoading}
+                        aria-invalid={!!fieldErrors.name || undefined}
+                        aria-describedby={fieldErrors.name ? "signup-name-error" : undefined}
                     />
-                    <button
-                        type="button"
-                        onClick={() => setShowPassword((prev) => !prev)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                        disabled={isLoading}
-                    >
-                        {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
+                    <FieldError id="signup-name-error">{fieldErrors.name}</FieldError>
                 </div>
 
-                <div className="relative">
+                <div>
+                    <label htmlFor="signup-email" className="sr-only">University email</label>
                     <Input
-                        name="confirmPassword"
-                        type={showConfirmPassword ? "text" : "password"}
-                        placeholder="Confirm password"
-                        className="h-10 pr-10"
+                        id="signup-email"
+                        name="email"
+                        type="email"
+                        placeholder="University email"
+                        className="h-10"
                         required
-                        minLength={8}
                         disabled={isLoading}
+                        aria-invalid={!!fieldErrors.email || undefined}
+                        aria-describedby={fieldErrors.email ? "signup-email-error" : undefined}
                     />
-                    <button
-                        type="button"
-                        onClick={() => setShowConfirmPassword((prev) => !prev)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                        disabled={isLoading}
-                    >
-                        {showConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
+                    <FieldError id="signup-email-error">{fieldErrors.email}</FieldError>
+                </div>
+
+                <div>
+                    <Select value={majorId} onValueChange={(v) => { setMajorId(v); setFieldErrors((p) => ({ ...p, major: undefined })); }} disabled={isMajorsLoading || isMajorsError || isLoading}>
+                        <SelectTrigger className="h-10" aria-invalid={!!fieldErrors.major || undefined} aria-describedby={fieldErrors.major ? "signup-major-error" : undefined}>
+                            <SelectValue placeholder={isMajorsLoading ? "Loading majors..." : isMajorsError ? "Couldn't load majors — refresh to try again" : "Select Major"}>
+                                {majors?.find((m) => m.id === majorId)?.name}
+                            </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                            {majors?.map((major) => (
+                                <SelectItem key={major.id} value={major.id}>
+                                    {major.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <FieldError id="signup-major-error">{fieldErrors.major}</FieldError>
+                </div>
+
+                <div>
+                    <label htmlFor="signup-password" className="sr-only">Password</label>
+                    <div className="relative">
+                        <Input
+                            id="signup-password"
+                            name="password"
+                            type={showPassword ? "text" : "password"}
+                            placeholder="Password (at least 8 characters)"
+                            className="h-10 pr-10"
+                            required
+                            minLength={8}
+                            disabled={isLoading}
+                            aria-invalid={!!fieldErrors.password || undefined}
+                            aria-describedby={fieldErrors.password ? "signup-password-error" : undefined}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowPassword((prev) => !prev)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                            disabled={isLoading}
+                            aria-label={showPassword ? "Hide password" : "Show password"}
+                        >
+                            {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                        </button>
+                    </div>
+                    <FieldError id="signup-password-error">{fieldErrors.password}</FieldError>
+                </div>
+
+                <div>
+                    <label htmlFor="signup-confirm" className="sr-only">Confirm password</label>
+                    <div className="relative">
+                        <Input
+                            id="signup-confirm"
+                            name="confirmPassword"
+                            type={showConfirmPassword ? "text" : "password"}
+                            placeholder="Confirm password"
+                            className="h-10 pr-10"
+                            required
+                            minLength={8}
+                            disabled={isLoading}
+                            aria-invalid={!!fieldErrors.confirmPassword || undefined}
+                            aria-describedby={fieldErrors.confirmPassword ? "signup-confirm-error" : undefined}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowConfirmPassword((prev) => !prev)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                            disabled={isLoading}
+                            aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+                        >
+                            {showConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                        </button>
+                    </div>
+                    <FieldError id="signup-confirm-error">{fieldErrors.confirmPassword}</FieldError>
                 </div>
             </div>
+
+            <FormErrorSummary message={formError} autoFocus className="w-full mt-4" />
 
             <Button
                 className="rounded-full w-full px-12 py-6 mt-6 font-bold uppercase text-xs tracking-wider transition-transform active:scale-95"
@@ -149,8 +198,6 @@ export default function SignUpForm() {
             >
                 {isLoading ? <Loader2 className="animate-spin h-4 w-4" /> : "Sign Up"}
             </Button>
-
-            {error && <p className="text-red-500 text-xs mt-2">{error}</p>}
         </form>
     );
 }

--- a/src/features/files/hooks/useRequests.ts
+++ b/src/features/files/hooks/useRequests.ts
@@ -42,7 +42,7 @@ import {
     getRequestPreviewUrl,
 } from "@/features/files/api/requestService";
 import { toast } from "sonner";
-import { ApiError } from "@/lib/apiClient";
+import { toastError } from "@/lib/errors";
 import type { RejectReason, FileStatus } from "@/types/domain";
 import { queryKeys } from "@/lib/queryKeys";
 
@@ -80,8 +80,10 @@ export const useCreateRequest = () => {
             toast.success("File submitted successfully");
         },
         onError: (err) => {
-            const detail = err instanceof ApiError ? err.message : null;
-            toast.error(detail || "Failed to submit file. Try again.");
+            toastError(err, {
+                context: "upload",
+                fallbackMessage: "We couldn't submit your file. Please try again, or choose a smaller file.",
+            });
         },
     });
 };
@@ -99,8 +101,8 @@ export const useWithdrawRequest = () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.requests.mine() });
             toast.success("Request withdrawn");
         },
-        onError: () => {
-            toast.error("Failed to withdraw request. Try again.");
+        onError: (err) => {
+            toastError(err, { fallbackMessage: "We couldn't withdraw your request. Please try again." });
         },
     });
 };
@@ -181,8 +183,8 @@ export const useApproveRequest = () => {
                 });
             }
         },
-        onError: () => {
-            toast.error("Failed to approve request");
+        onError: (err) => {
+            toastError(err, { fallbackMessage: "We couldn't approve this request. Please try again." });
         },
     });
 };
@@ -226,8 +228,8 @@ export const useRejectRequest = () => {
                 });
             }
         },
-        onError: () => {
-            toast.error("Failed to reject request");
+        onError: (err) => {
+            toastError(err, { fallbackMessage: "We couldn't reject this request. Please try again." });
         },
     });
 };
@@ -249,8 +251,8 @@ export const useBulkApprove = () => {
                 (result.skipped > 0 ? ` (${result.skipped} skipped)` : "")
             );
         },
-        onError: () => {
-            toast.error("Failed to bulk approve");
+        onError: (err) => {
+            toastError(err, { fallbackMessage: "We couldn't approve those requests. Please try again." });
         },
     });
 };
@@ -278,8 +280,8 @@ export const useBulkReject = () => {
                 (result.skipped > 0 ? ` (${result.skipped} skipped)` : "")
             );
         },
-        onError: () => {
-            toast.error("Failed to bulk reject");
+        onError: (err) => {
+            toastError(err, { fallbackMessage: "We couldn't reject those requests. Please try again." });
         },
     });
 };

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { normalizeError } from "@/lib/errors";
+import { ApiError } from "@/lib/apiClient";
+
+describe("normalizeError — HTTP status → kind mapping", () => {
+    const cases: Array<[number, string]> = [
+        [401, "authentication"],
+        [403, "authorization"],
+        [404, "notFound"],
+        [409, "conflict"],
+        [429, "rateLimit"],
+        [402, "payment"],
+        [422, "validation"],
+        [400, "validation"],
+        [500, "server"],
+        [503, "server"],
+    ];
+
+    it.each(cases)("maps status %i to kind '%s'", (status, kind) => {
+        const n = normalizeError(new ApiError(status, "raw", { detail: "raw detail" }));
+        expect(n.kind).toBe(kind);
+        // Never empty, always actionable.
+        expect(n.title.length).toBeGreaterThan(0);
+        expect(n.message.length).toBeGreaterThan(0);
+    });
+});
+
+describe("normalizeError — transport & unknown", () => {
+    it("treats a status-0 ApiError as a network error with retry", () => {
+        const n = normalizeError(new ApiError(0, "Network request failed"));
+        expect(n.kind).toBe("network");
+        expect(n.retryable).toBe(true);
+        expect(n.message.toLowerCase()).toContain("connection");
+    });
+
+    it("treats a fetch TypeError as a network error", () => {
+        const n = normalizeError(new TypeError("Failed to fetch"));
+        expect(n.kind).toBe("network");
+    });
+
+    it("falls back to a safe unknown message for a plain string throw", () => {
+        const n = normalizeError("boom");
+        expect(n.kind).toBe("unknown");
+        expect(n.message).toBeTruthy();
+    });
+});
+
+describe("normalizeError — validation field extraction", () => {
+    it("pulls { field: message } out of a FastAPI 422 body and camelCases keys", () => {
+        const n = normalizeError(
+            new ApiError(422, "Unprocessable", {
+                detail: [
+                    { loc: ["body", "email"], msg: "value is not a valid email address" },
+                    { loc: ["body", "password_confirm"], msg: "field required" },
+                ],
+            }),
+        );
+        expect(n.kind).toBe("validation");
+        expect(n.fieldErrors?.email).toContain("valid email");
+        expect(n.fieldErrors?.passwordConfirm).toBe("This field is required.");
+    });
+});
+
+describe("normalizeError — sanitization & rewrites", () => {
+    it("rewrites a raw credential error into a friendly one", () => {
+        const n = normalizeError(new ApiError(401, "x", { detail: "Wrong email or password" }));
+        expect(n.message.toLowerCase()).toContain("email or password");
+        expect(n.message.toLowerCase()).not.toContain("wrong email or password");
+    });
+
+    it("suppresses leaked internals (SQL / tracebacks) in favour of a safe default", () => {
+        const n = normalizeError(
+            new ApiError(500, "x", { detail: "IntegrityError: null value in column 'id' violates not-null" }),
+        );
+        expect(n.message).not.toContain("IntegrityError");
+        expect(n.message).not.toContain("null value");
+        // The safe server-error default is used instead.
+        expect(n.kind).toBe("server");
+    });
+
+    it("honours a context hint to upgrade a generic bucket", () => {
+        const n = normalizeError(new ApiError(400, "x", {}), { context: "upload" });
+        expect(n.kind).toBe("upload");
+    });
+
+    it("uses a provided fallbackMessage when no safe backend message exists", () => {
+        const n = normalizeError(new ApiError(500, "x", {}), { fallbackMessage: "Custom fallback." });
+        expect(n.message).toBe("Custom fallback.");
+    });
+});

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -75,6 +75,10 @@ export function snakeToCamel<T>(data: unknown): T {
 
 /**
  * Typed API error with status code, message, and raw response data.
+ *
+ * A `status` of 0 is reserved for transport-level failures (the request never
+ * reached the server: offline, DNS, CORS, timeout). Use {@link isNetworkError}
+ * rather than checking the status directly.
  */
 export class ApiError extends Error {
     status: number;
@@ -85,6 +89,27 @@ export class ApiError extends Error {
         this.name = "ApiError";
         this.status = status;
         this.data = data;
+    }
+}
+
+/**
+ * True when a failure means "we never got a response" — an ApiError tagged with
+ * status 0, or a raw fetch `TypeError` that escaped the wrapper. The error layer
+ * turns these into a "Connection problem" message with a retry affordance.
+ */
+export function isNetworkError(err: unknown): boolean {
+    if (err instanceof ApiError) return err.status === 0;
+    // Native fetch rejects with a TypeError on network/CORS failure.
+    return err instanceof TypeError && /fetch|network|load failed/i.test(err.message);
+}
+
+/** Wrap the native fetch so transport failures become a status-0 ApiError. */
+async function safeFetch(input: string, init?: RequestInit): Promise<Response> {
+    try {
+        return await fetch(input, init);
+    } catch (err) {
+        if (err instanceof ApiError) throw err;
+        throw new ApiError(0, "Network request failed", err);
     }
 }
 
@@ -113,7 +138,7 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
         delete headers["Content-Type"];
     }
 
-    const res = await fetch(`${API_BASE_URL}${path}`, {
+    const res = await safeFetch(`${API_BASE_URL}${path}`, {
         ...init,
         headers,
         credentials: "include", // Ready for HTTP-only cookies
@@ -146,7 +171,7 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
-    const res = await fetch(`${API_BASE_URL}${path}`, {
+    const res = await safeFetch(`${API_BASE_URL}${path}`, {
         ...init,
         credentials: "include",
     });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,308 @@
+/**
+ * ============================================================================
+ * ERROR NORMALIZATION & TAXONOMY
+ * ============================================================================
+ *
+ * The single source of truth for turning any thrown value — an ApiError, a
+ * network failure, a FastAPI validation envelope, or an unknown exception —
+ * into a calm, plain-language, actionable message for the user.
+ *
+ * Rules this layer enforces (see the platform error guidelines):
+ *   - Plain language, no jargon, no stack traces, no raw provider payloads.
+ *   - Every message says what happened and what to do next.
+ *   - Unknown failures fall back to a safe, reassuring default.
+ *   - Raw details go to the developer logger, never to the user.
+ *
+ * Consumers should never read `ApiError.message`/`.data` directly for display;
+ * always route through `normalizeError()` (or `toastError()`).
+ * ============================================================================
+ */
+
+import { toast } from "sonner";
+import { ApiError, isNetworkError } from "@/lib/apiClient";
+import { logger } from "@/lib/logger";
+
+// ── Taxonomy ────────────────────────────────────────────────────────────────
+
+export type ErrorKind =
+    | "validation"
+    | "authentication"
+    | "authorization"
+    | "notFound"
+    | "conflict"
+    | "rateLimit"
+    | "network"
+    | "server"
+    | "payment"
+    | "upload"
+    | "unknown";
+
+/** A user-safe, fully-resolved error ready to render anywhere in the UI. */
+export interface NormalizedError {
+    kind: ErrorKind;
+    /** Short headline — "what happened". */
+    title: string;
+    /** One or two calm sentences — what happened + what to do next. */
+    message: string;
+    /** True for transient failures where a "Try again" affordance makes sense. */
+    retryable: boolean;
+    /** Field-name → message map, populated from validation (422) responses. */
+    fieldErrors?: Record<string, string>;
+}
+
+// ── Default copy per kind ─────────────────────────────────────────────────────
+// Every fallback answers: what happened + what to do next. No blame, no codes.
+
+const DEFAULTS: Record<ErrorKind, { title: string; message: string; retryable: boolean }> = {
+    validation: {
+        title: "Check your details",
+        message: "Some information needs a quick fix. Review the highlighted fields and try again.",
+        retryable: false,
+    },
+    authentication: {
+        title: "Your session expired",
+        message: "For your security, please sign in again to continue.",
+        retryable: false,
+    },
+    authorization: {
+        title: "You don't have access",
+        message: "You don't have permission to do this. If you think this is a mistake, contact an admin.",
+        retryable: false,
+    },
+    notFound: {
+        title: "Not found",
+        message: "This item was already removed or no longer exists. Try refreshing the page.",
+        retryable: false,
+    },
+    conflict: {
+        title: "That didn't go through",
+        message: "This conflicts with something that already exists. Review your changes and try again.",
+        retryable: false,
+    },
+    rateLimit: {
+        title: "Too many attempts",
+        message: "You've tried that a few times. Please wait a moment, then try again.",
+        retryable: true,
+    },
+    network: {
+        title: "Connection problem",
+        message: "We couldn't reach the server. Check your internet connection and try again.",
+        retryable: true,
+    },
+    server: {
+        title: "Something went wrong on our end",
+        message: "This is on us, not you. Please try again in a moment — we're on it.",
+        retryable: true,
+    },
+    payment: {
+        title: "Payment didn't complete",
+        message: "Your payment couldn't be processed. No charge was made. Check your details and try again.",
+        retryable: true,
+    },
+    upload: {
+        title: "Upload didn't finish",
+        message: "We couldn't upload that file. Try again, or choose a smaller file.",
+        retryable: true,
+    },
+    unknown: {
+        title: "Something went wrong",
+        message: "That didn't work as expected. Please try again in a moment.",
+        retryable: true,
+    },
+};
+
+// ── HTTP status → kind ────────────────────────────────────────────────────────
+
+function kindFromStatus(status: number): ErrorKind {
+    switch (status) {
+        case 400:
+        case 422:
+            return "validation";
+        case 401:
+            return "authentication";
+        case 403:
+            return "authorization";
+        case 404:
+            return "notFound";
+        case 402:
+            return "payment";
+        case 409:
+            return "conflict";
+        case 429:
+            return "rateLimit";
+        default:
+            if (status === 0) return "network";
+            if (status >= 500) return "server";
+            if (status >= 400) return "validation";
+            return "unknown";
+    }
+}
+
+// ── FastAPI envelope helpers ──────────────────────────────────────────────────
+
+interface ValidationItem {
+    loc?: (string | number)[];
+    msg?: string;
+    [key: string]: unknown;
+}
+
+/** camelCase-ify a snake_case field name so it matches frontend form field ids. */
+function toField(name: string): string {
+    return name.replace(/_([a-z0-9])/g, (_m, c: string) => c.toUpperCase());
+}
+
+/**
+ * Pull a clean, user-safe string out of FastAPI's `{ detail: ... }` envelope.
+ * Handles the string form, the `{ msg }` object form, and the array-of-items
+ * (422) form. Returns `undefined` when there's nothing human-readable.
+ */
+function detailToMessage(detail: unknown): string | undefined {
+    if (typeof detail === "string") return detail;
+    if (Array.isArray(detail)) {
+        const msgs = detail
+            .map((d: ValidationItem) => (typeof d?.msg === "string" ? cleanValidationMsg(d.msg) : undefined))
+            .filter(Boolean);
+        return msgs.length ? (msgs as string[]).join(" ") : undefined;
+    }
+    if (detail && typeof detail === "object" && typeof (detail as ValidationItem).msg === "string") {
+        return cleanValidationMsg((detail as ValidationItem).msg as string);
+    }
+    return undefined;
+}
+
+/** Map a FastAPI 422 body to a { field: message } dictionary for inline display. */
+function fieldErrorsFromDetail(detail: unknown): Record<string, string> | undefined {
+    if (!Array.isArray(detail)) return undefined;
+    const out: Record<string, string> = {};
+    for (const item of detail as ValidationItem[]) {
+        const loc = item.loc ?? [];
+        // loc is typically ["body", "field_name"] — take the last string segment.
+        const raw = [...loc].reverse().find((seg) => typeof seg === "string" && seg !== "body");
+        if (typeof raw === "string" && item.msg) {
+            out[toField(raw)] = cleanValidationMsg(item.msg);
+        }
+    }
+    return Object.keys(out).length ? out : undefined;
+}
+
+/** Strip Pydantic's noisy prefixes and make the message read like a fix. */
+function cleanValidationMsg(msg: string): string {
+    const cleaned = msg
+        .replace(/^Value error,\s*/i, "")
+        .replace(/^Assertion failed,\s*/i, "")
+        .trim();
+    if (/field required/i.test(cleaned)) return "This field is required.";
+    if (/valid email/i.test(cleaned)) return "Enter a valid email address, like name@example.com.";
+    return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+// ── Known-message rewrites ────────────────────────────────────────────────────
+// Backend messages that are already user-facing but could read friendlier, or
+// that leak internals we'd rather not surface verbatim.
+
+function rewriteKnownMessage(raw: string): string | undefined {
+    const m = raw.toLowerCase();
+    if (m.includes("wrong email or password") || m.includes("invalid credentials")) {
+        return "That email or password doesn't match. Check them and try again.";
+    }
+    if (m.includes("passwordstrength")) {
+        return "Your password is too weak. Use at least 8 characters with an uppercase letter, a lowercase letter, and a number.";
+    }
+    if (m.includes("email") && m.includes("already") && (m.includes("registered") || m.includes("exists"))) {
+        return "An account with this email already exists. Try signing in instead.";
+    }
+    // Anything that smells like a raw exception / SQL / stack — suppress it.
+    if (/traceback|exception|sqlalchemy|psycopg|null value|integrityerror|keyerror|at 0x[0-9a-f]+/i.test(raw)) {
+        return undefined;
+    }
+    return raw;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface NormalizeOptions {
+    /** Domain hint so the message fits the action, e.g. "upload" or "payment". */
+    context?: ErrorKind;
+    /** Overrides the fallback message for the resolved (or unknown) kind. */
+    fallbackMessage?: string;
+}
+
+/**
+ * Convert any thrown value into a user-safe {@link NormalizedError}.
+ * Always logs the raw error for developers; never surfaces internals.
+ */
+export function normalizeError(err: unknown, opts: NormalizeOptions = {}): NormalizedError {
+    // Developer-facing log (silent in production) — the raw truth lives here.
+    logger.error("[normalizeError]", err);
+
+    // Network / offline: fetch throws a TypeError, or apiClient tagged status 0.
+    if (isNetworkError(err)) {
+        return withFallback("network", opts);
+    }
+
+    if (err instanceof ApiError) {
+        let kind = kindFromStatus(err.status);
+        // A context hint upgrades a generic bucket to the domain-specific one
+        // (e.g. a 400 during an upload should read as an upload error).
+        if (opts.context && (kind === "validation" || kind === "server" || kind === "unknown")) {
+            kind = opts.context;
+        }
+
+        const data = err.data as { detail?: unknown; message?: string; error_description?: string } | undefined;
+        const fieldErrors = fieldErrorsFromDetail(data?.detail);
+
+        // Prefer a specific backend message when it's genuinely user-facing.
+        const rawMessage =
+            detailToMessage(data?.detail) ?? data?.message ?? data?.error_description ?? undefined;
+        const safeMessage = rawMessage ? rewriteKnownMessage(rawMessage) : undefined;
+
+        const base = DEFAULTS[kind];
+        return {
+            kind,
+            title: base.title,
+            // For validation with field errors, keep the summary generic and let
+            // the fields carry specifics. Otherwise prefer the safe backend text.
+            message:
+                (kind === "validation" && fieldErrors
+                    ? base.message
+                    : safeMessage || opts.fallbackMessage || base.message),
+            retryable: base.retryable,
+            fieldErrors,
+        };
+    }
+
+    // Plain Error or unknown throw.
+    return withFallback(opts.context ?? "unknown", opts);
+}
+
+function withFallback(kind: ErrorKind, opts: NormalizeOptions): NormalizedError {
+    const base = DEFAULTS[kind];
+    return {
+        kind,
+        title: base.title,
+        message: opts.fallbackMessage || base.message,
+        retryable: base.retryable,
+    };
+}
+
+/**
+ * Normalize `err` and show it as a toast. Critical, non-retryable errors stay
+ * on screen longer (and permission/auth errors persist) so users can act; a
+ * retry-shaped failure keeps the standard duration. Returns the normalized
+ * error so callers can also drive inline UI if they want.
+ */
+export function toastError(err: unknown, opts: NormalizeOptions = {}): NormalizedError {
+    const n = normalizeError(err, opts);
+    const critical = n.kind === "authorization" || n.kind === "authentication";
+    toast.error(n.title, {
+        description: n.message,
+        // Persist critical errors; give server/network a comfortable read.
+        duration: critical ? Infinity : n.retryable ? 6000 : 5000,
+    });
+    return n;
+}
+
+/** Convenience for success toasts so tone stays consistent across the app. */
+export function toastSuccess(message: string, description?: string): void {
+    toast.success(message, description ? { description } : undefined);
+}

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode, type ErrorInfo } from "react";
 import { AlertTriangle, RefreshCw } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 interface Props {
     children: ReactNode;
@@ -21,7 +22,8 @@ export default class ErrorBoundary extends Component<Props, State> {
     }
 
     componentDidCatch(error: Error, info: ErrorInfo) {
-        console.error("[ErrorBoundary]", error, info.componentStack);
+        // Developer-only — silent in production so internals never leak to DevTools.
+        logger.error("[ErrorBoundary]", error, info.componentStack);
     }
 
     handleReset = () => {
@@ -31,17 +33,19 @@ export default class ErrorBoundary extends Component<Props, State> {
     render() {
         if (this.state.hasError) {
             return (
-                <div className="min-h-screen bg-background flex items-center justify-center p-8">
+                <div className="min-h-screen bg-background flex items-center justify-center p-8" role="alert">
                     <div className="text-center max-w-md">
                         <div className="w-16 h-16 rounded-2xl bg-red-500/10 flex items-center justify-center mx-auto mb-6">
-                            <AlertTriangle className="h-7 w-7 text-red-400" />
+                            <AlertTriangle className="h-7 w-7 text-red-400" aria-hidden="true" />
                         </div>
                         <h1 className="text-[24px] font-display font-bold text-foreground">Something went wrong</h1>
                         <p className="text-[14px] text-muted-foreground mt-2 max-w-sm mx-auto">
-                            An unexpected error occurred. Try refreshing, or contact support if the problem persists.
+                            The app hit an unexpected problem — this is on us, not you. Try again, and if it keeps
+                            happening, please contact support.
                         </p>
-                        {this.state.error && (
-                            <pre className="mt-4 p-3 rounded-xl bg-foreground/5 border border-border text-[12px] text-red-400/80 text-left overflow-auto max-h-32">
+                        {/* Raw error is shown only in development, never to real users. */}
+                        {import.meta.env.DEV && this.state.error && (
+                            <pre className="mt-4 p-3 rounded-xl bg-foreground/5 border border-border text-[12px] text-muted-foreground text-left overflow-auto max-h-32">
                                 {this.state.error.message}
                             </pre>
                         )}
@@ -49,8 +53,8 @@ export default class ErrorBoundary extends Component<Props, State> {
                             onClick={this.handleReset}
                             className="mt-6 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl gradient-bg text-foreground text-[14px] font-medium hover:opacity-90 transition-opacity"
                         >
-                            <RefreshCw className="h-4 w-4" />
-                            Try Again
+                            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                            Try again
                         </button>
                     </div>
                 </div>

--- a/src/shared/components/errors/DestructiveActionWarning.tsx
+++ b/src/shared/components/errors/DestructiveActionWarning.tsx
@@ -1,0 +1,36 @@
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface DestructiveActionWarningProps {
+    /** What is about to happen and why it can't be undone. */
+    children: string;
+    className?: string;
+}
+
+/**
+ * A calm, high-contrast warning block for use inside a confirmation dialog
+ * before a destructive action (delete, reject, bulk remove). Icon + text so the
+ * caution never rests on color alone; `role="alert"` so it's announced when the
+ * dialog opens.
+ *
+ * @example
+ * <Dialog>
+ *   <DestructiveActionWarning>
+ *     This permanently deletes 12 files. This can't be undone.
+ *   </DestructiveActionWarning>
+ * </Dialog>
+ */
+export function DestructiveActionWarning({ children, className }: DestructiveActionWarningProps) {
+    return (
+        <div
+            role="alert"
+            className={cn(
+                "flex items-start gap-2.5 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3.5 py-3",
+                className,
+            )}
+        >
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+            <p className="text-[13px] text-amber-800 dark:text-amber-200">{children}</p>
+        </div>
+    );
+}

--- a/src/shared/components/errors/EmptyOrErrorState.tsx
+++ b/src/shared/components/errors/EmptyOrErrorState.tsx
@@ -1,0 +1,45 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { EmptyState } from "@/shared/components/EmptyState";
+import { PageErrorState } from "./PageErrorState";
+
+interface EmptyOrErrorStateProps {
+    /** True when the underlying query/request failed. */
+    isError?: boolean;
+    /** The raw error, forwarded to PageErrorState for friendly copy. */
+    error?: unknown;
+    /** Retry handler for the error branch (e.g. `refetch`). */
+    onRetry?: () => void;
+
+    // Empty-state props (used when there's no error, just no data).
+    icon: LucideIcon;
+    title: string;
+    description?: string;
+    action?: ReactNode;
+    className?: string;
+}
+
+/**
+ * One switch for a data region that can be either **empty** or **failed**.
+ *
+ * Keeps the two visually consistent while giving a failed load its own honest,
+ * retryable message instead of pretending the list is simply empty. Use it
+ * wherever a list/grid renders `data?.length ? … : <EmptyState/>`.
+ */
+export function EmptyOrErrorState({
+    isError,
+    error,
+    onRetry,
+    icon,
+    title,
+    description,
+    action,
+    className,
+}: EmptyOrErrorStateProps) {
+    if (isError || error) {
+        return <PageErrorState error={error} onRetry={onRetry} className={className} />;
+    }
+    return (
+        <EmptyState icon={icon} title={title} description={description} action={action} className={className} />
+    );
+}

--- a/src/shared/components/errors/FieldError.tsx
+++ b/src/shared/components/errors/FieldError.tsx
@@ -1,0 +1,37 @@
+import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FieldErrorProps {
+    /** The error text. When empty/undefined nothing renders. */
+    children?: string | null;
+    /**
+     * Stable id so the matching input can point to it via
+     * `aria-describedby`. Convention: `${fieldName}-error`.
+     */
+    id?: string;
+    className?: string;
+}
+
+/**
+ * Inline, accessible error shown directly beneath a form field.
+ *
+ * Communicates with an icon **and** text (never color alone) and announces
+ * itself to screen readers via `role="alert"`. Pair it with an input that sets
+ * `aria-invalid` and `aria-describedby={id}`.
+ */
+export function FieldError({ children, id, className }: FieldErrorProps) {
+    if (!children) return null;
+    return (
+        <p
+            id={id}
+            role="alert"
+            className={cn(
+                "flex items-start gap-1.5 text-[12px] font-medium text-red-600 dark:text-red-400 mt-1.5",
+                className,
+            )}
+        >
+            <AlertCircle className="h-3.5 w-3.5 mt-[1px] shrink-0" aria-hidden="true" />
+            <span>{children}</span>
+        </p>
+    );
+}

--- a/src/shared/components/errors/FormErrorSummary.tsx
+++ b/src/shared/components/errors/FormErrorSummary.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FormErrorSummaryProps {
+    /** Headline — "what happened". Falls back to a friendly default. */
+    title?: string;
+    /** One or two calm sentences. When empty the summary does not render. */
+    message?: string | null;
+    /** When true, moves keyboard focus to the summary on mount (submit failure). */
+    autoFocus?: boolean;
+    className?: string;
+}
+
+/**
+ * Form-level error banner shown above (or below) a form after a submit fails
+ * for a reason that isn't tied to one field — a network drop, a server error,
+ * "email already registered", etc.
+ *
+ * Uses an icon + text, `role="alert"` for immediate announcement, and can pull
+ * focus so keyboard and screen-reader users land on the explanation.
+ */
+export function FormErrorSummary({ title, message, autoFocus, className }: FormErrorSummaryProps) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (autoFocus && message) ref.current?.focus();
+    }, [autoFocus, message]);
+
+    if (!message) return null;
+
+    return (
+        <div
+            ref={ref}
+            role="alert"
+            tabIndex={-1}
+            className={cn(
+                "flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3 text-left outline-none",
+                className,
+            )}
+        >
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-red-600 dark:text-red-400" aria-hidden="true" />
+            <div className="space-y-0.5">
+                {title && <p className="text-[13px] font-semibold text-red-700 dark:text-red-300">{title}</p>}
+                <p className="text-[13px] text-red-700/90 dark:text-red-200/90">{message}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/shared/components/errors/InlineError.tsx
+++ b/src/shared/components/errors/InlineError.tsx
@@ -1,0 +1,28 @@
+import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface InlineErrorProps {
+    children?: string | null;
+    className?: string;
+}
+
+/**
+ * A compact, standalone error line for use outside form fields — next to an
+ * action, in a list row, under a control. Icon + text (never color alone),
+ * announced with `role="alert"`.
+ */
+export function InlineError({ children, className }: InlineErrorProps) {
+    if (!children) return null;
+    return (
+        <p
+            role="alert"
+            className={cn(
+                "flex items-start gap-1.5 text-[13px] text-red-600 dark:text-red-400",
+                className,
+            )}
+        >
+            <AlertCircle className="h-4 w-4 mt-[1px] shrink-0" aria-hidden="true" />
+            <span>{children}</span>
+        </p>
+    );
+}

--- a/src/shared/components/errors/PageErrorState.tsx
+++ b/src/shared/components/errors/PageErrorState.tsx
@@ -1,0 +1,69 @@
+import { AlertTriangle, RefreshCw, WifiOff, Lock, SearchX } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { normalizeError, type ErrorKind } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+
+interface PageErrorStateProps {
+    /** The raw error — normalized internally into safe, friendly copy. */
+    error?: unknown;
+    /** Override the normalized title. */
+    title?: string;
+    /** Override the normalized message. */
+    message?: string;
+    /** Retry handler. When provided (and the error is retryable) a button shows. */
+    onRetry?: () => void;
+    retryLabel?: string;
+    className?: string;
+}
+
+const ICONS: Record<ErrorKind, LucideIcon> = {
+    network: WifiOff,
+    authorization: Lock,
+    authentication: Lock,
+    notFound: SearchX,
+    validation: AlertTriangle,
+    conflict: AlertTriangle,
+    rateLimit: AlertTriangle,
+    server: AlertTriangle,
+    payment: AlertTriangle,
+    upload: AlertTriangle,
+    unknown: AlertTriangle,
+};
+
+/**
+ * Full-region error state for a page or panel whose data failed to load —
+ * dashboards, lists, detail views. Replaces bare "Something went wrong" blocks.
+ *
+ * Normalizes the error into plain language and offers a retry when the failure
+ * is transient. Announced to assistive tech via `role="alert"`.
+ */
+export function PageErrorState({ error, title, message, onRetry, retryLabel, className }: PageErrorStateProps) {
+    const n = normalizeError(error);
+    const Icon = ICONS[n.kind];
+    const showRetry = !!onRetry && (n.retryable || !error);
+
+    return (
+        <div
+            role="alert"
+            className={cn(
+                "liquid-glass rounded-2xl p-10 text-center flex flex-col items-center",
+                className,
+            )}
+        >
+            <div className="w-14 h-14 rounded-2xl bg-red-500/10 flex items-center justify-center mb-4">
+                <Icon className="h-6 w-6 text-red-500/80" aria-hidden="true" />
+            </div>
+            <p className="text-[15px] font-display font-semibold text-foreground">{title ?? n.title}</p>
+            <p className="text-[13px] text-muted-foreground mt-1.5 max-w-sm">{message ?? n.message}</p>
+            {showRetry && (
+                <button
+                    onClick={onRetry}
+                    className="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-xl gradient-bg text-foreground text-[13px] font-medium hover:opacity-90 transition-opacity"
+                >
+                    <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+                    {retryLabel ?? "Try again"}
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/shared/components/errors/RetryNotice.tsx
+++ b/src/shared/components/errors/RetryNotice.tsx
@@ -1,0 +1,44 @@
+import { RefreshCw, AlertCircle } from "lucide-react";
+import { normalizeError } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+
+interface RetryNoticeProps {
+    /** Raw error, normalized into safe copy internally. */
+    error?: unknown;
+    /** Override the normalized message. */
+    message?: string;
+    onRetry: () => void;
+    retryLabel?: string;
+    className?: string;
+}
+
+/**
+ * Compact inline banner for a transient failure inside otherwise-loaded UI —
+ * a widget that couldn't refresh, a section that failed while the rest of the
+ * page is fine. Pairs a plain-language message with a retry button. Prefer this
+ * over a disappearing toast when the user needs the action to stay visible.
+ */
+export function RetryNotice({ error, message, onRetry, retryLabel, className }: RetryNoticeProps) {
+    const n = normalizeError(error);
+    return (
+        <div
+            role="alert"
+            className={cn(
+                "flex items-center justify-between gap-3 rounded-xl border border-border bg-foreground/[0.03] px-3.5 py-2.5",
+                className,
+            )}
+        >
+            <p className="flex items-center gap-2 text-[13px] text-muted-foreground">
+                <AlertCircle className="h-4 w-4 shrink-0 text-amber-500" aria-hidden="true" />
+                <span>{message ?? n.message}</span>
+            </p>
+            <button
+                onClick={onRetry}
+                className="inline-flex items-center gap-1.5 shrink-0 text-[13px] font-medium text-foreground hover:opacity-80 transition-opacity"
+            >
+                <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+                {retryLabel ?? "Retry"}
+            </button>
+        </div>
+    );
+}

--- a/src/shared/components/errors/RouteError.tsx
+++ b/src/shared/components/errors/RouteError.tsx
@@ -1,21 +1,85 @@
+import { useEffect } from "react";
 import { useRouteError } from "react-router-dom";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+import { logger } from "@/lib/logger";
 
 interface RouteErrorProps {
     name?: string;
 }
 
-export default function RouteError({ name = "Application" }: RouteErrorProps) {
+const CHUNK_RELOAD_KEY = "gh_chunk_reload_at";
+const CHUNK_RELOAD_COOLDOWN_MS = 10_000;
+
+// A route chunk's hashed filename no longer exists on the server (superseded
+// by a new deploy while this tab was open); the SPA fallback then serves
+// index.html for it, which the module loader rejects as the wrong MIME type.
+function isStaleChunkError(message: string) {
+    // Each engine phrases the failed dynamic import differently:
+    // Chrome "Failed to fetch dynamically imported module",
+    // Firefox "error loading dynamically imported module",
+    // Safari/WebKit "Importing a module script failed".
+    return /dynamically imported module|importing a module script failed/i.test(message);
+}
+
+export default function RouteError({ name = "page" }: RouteErrorProps) {
     const error = useRouteError();
-    console.error(error);
+    // Developer-only — the raw error is never shown to users in production.
+    logger.error("[RouteError]", error);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rawMessage = String((error as any)?.statusText || (error as any)?.message || "");
+    const isStaleChunk = isStaleChunkError(rawMessage);
+
+    useEffect(() => {
+        if (!isStaleChunk) return;
+        const lastReload = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY) || 0);
+        if (Date.now() - lastReload < CHUNK_RELOAD_COOLDOWN_MS) return;
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+        window.location.reload();
+    }, [isStaleChunk]);
+
+    if (isStaleChunk) {
+        return (
+            <div className="p-8 flex flex-col items-center justify-center min-h-[50vh] text-center">
+                <h1 className="text-2xl font-bold text-foreground mb-3">Updating to the latest version…</h1>
+                <p className="text-muted-foreground">A new version of GeeksHub was just released. Reloading now.</p>
+            </div>
+        );
+    }
 
     return (
-        <div className="p-8 flex flex-col items-center justify-center min-h-[50vh] text-center">
-            <h1 className="text-2xl font-bold text-red-600 mb-4">Oops! Something went wrong.</h1>
-            <p className="text-slate-600 mb-2">An error occurred in the {name}.</p>
-            <p className="text-sm text-slate-400 font-mono mt-4">
-                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                {(error as any)?.statusText || (error as any)?.message || "Unknown error"}
-            </p>
+        <div className="min-h-[60vh] flex items-center justify-center p-8" role="alert">
+            <div className="text-center max-w-md">
+                <div className="w-14 h-14 rounded-2xl bg-red-500/10 flex items-center justify-center mx-auto mb-5">
+                    <AlertTriangle className="h-6 w-6 text-red-500/80" aria-hidden="true" />
+                </div>
+                <h1 className="text-[22px] font-display font-bold text-foreground">This {name} didn't load</h1>
+                <p className="text-[14px] text-muted-foreground mt-2 max-w-sm mx-auto">
+                    Something went wrong while loading this {name}. It's not your fault — try again, and if it
+                    keeps happening, head back home.
+                </p>
+                <div className="flex items-center justify-center gap-3 mt-6">
+                    <button
+                        onClick={() => window.location.reload()}
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl gradient-bg text-foreground text-[14px] font-medium hover:opacity-90 transition-opacity"
+                    >
+                        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                        Try again
+                    </button>
+                    <a
+                        href="/"
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-border text-foreground text-[14px] font-medium hover:bg-foreground/5 transition-colors"
+                    >
+                        <Home className="h-4 w-4" aria-hidden="true" />
+                        Go home
+                    </a>
+                </div>
+                {import.meta.env.DEV && rawMessage && (
+                    <pre className="mt-6 p-3 rounded-xl bg-foreground/5 border border-border text-[12px] text-muted-foreground text-left overflow-auto max-h-32">
+                        {rawMessage}
+                    </pre>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/shared/components/errors/__tests__/errorComponents.test.tsx
+++ b/src/shared/components/errors/__tests__/errorComponents.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FieldError } from "../FieldError";
+import { FormErrorSummary } from "../FormErrorSummary";
+import { PageErrorState } from "../PageErrorState";
+import { ApiError } from "@/lib/apiClient";
+
+describe("FieldError", () => {
+    it("renders nothing when there is no message", () => {
+        const { container } = render(<FieldError id="x-error">{null}</FieldError>);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("announces the error via role=alert and exposes the id for aria-describedby", () => {
+        render(<FieldError id="email-error">Enter a valid email address.</FieldError>);
+        const alert = screen.getByRole("alert");
+        expect(alert).toHaveAttribute("id", "email-error");
+        expect(alert).toHaveTextContent("Enter a valid email address.");
+    });
+});
+
+describe("FormErrorSummary", () => {
+    it("renders nothing without a message", () => {
+        const { container } = render(<FormErrorSummary message="" />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("shows title + message as an alert", () => {
+        render(<FormErrorSummary title="Your session expired" message="Please sign in again." />);
+        const alert = screen.getByRole("alert");
+        expect(alert).toHaveTextContent("Your session expired");
+        expect(alert).toHaveTextContent("Please sign in again.");
+    });
+});
+
+describe("PageErrorState", () => {
+    it("shows a friendly network message and a working retry for transient errors", () => {
+        let retried = 0;
+        render(<PageErrorState error={new ApiError(0, "Network request failed")} onRetry={() => { retried++; }} />);
+        expect(screen.getByRole("alert")).toHaveTextContent(/connection/i);
+        const btn = screen.getByRole("button", { name: /try again/i });
+        btn.click();
+        expect(retried).toBe(1);
+    });
+
+    it("does not offer retry for a non-retryable error (403)", () => {
+        render(<PageErrorState error={new ApiError(403, "forbidden", {})} onRetry={() => {}} />);
+        expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+    });
+});

--- a/src/shared/components/errors/index.ts
+++ b/src/shared/components/errors/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Central export for the platform error-UI kit. Import from
+ * `@/shared/components/errors` so every surface uses the same, accessible,
+ * plain-language patterns.
+ */
+export { FieldError } from "./FieldError";
+export { InlineError } from "./InlineError";
+export { FormErrorSummary } from "./FormErrorSummary";
+export { PageErrorState } from "./PageErrorState";
+export { RetryNotice } from "./RetryNotice";
+export { EmptyOrErrorState } from "./EmptyOrErrorState";
+export { DestructiveActionWarning } from "./DestructiveActionWarning";
+export { default as RouteError } from "./RouteError";


### PR DESCRIPTION
## Summary
Implements a unified, platform-wide error experience so every failure state is **calm, clear, actionable, consistent, and accessible** — replacing scattered "Something went wrong" / "Failed to X" strings and raw-error leaks.

## Audit — what was inconsistent
- **No normalization layer** — every feature hardcoded its own toast strings; only auth had a normalizer (unused elsewhere).
- **Raw internals leaked to users** — `ErrorBoundary` and `RouteError` rendered `error.message`/stack in a `<pre>`; backend leaked `PPTX conversion failed: {e}`, `str(e)`, and the user's role in a 403.
- **Forms failed a11y** — single red `<p>` (color-only), no icon/`role="alert"`, no `aria-invalid`, no focus-to-first-invalid.
- **Toast-only critical errors** that disappear before users can act; generic wording; no taxonomy for network/rate-limit/permission/conflict.

## What changed
**Core**
- `src/lib/errors.ts` — `ErrorKind` taxonomy + `normalizeError()` (maps status/network/422 → friendly `{title, message, retryable, fieldErrors}`, sanitizes SQL/tracebacks) + `toastError()` (persists auth/permission errors).
- `apiClient` — transport failures become a status-0 `ApiError`; `isNetworkError()`.

**Reusable error UI** (`src/shared/components/errors`): `FieldError`, `InlineError`, `FormErrorSummary`, `PageErrorState`, `RetryNotice`, `EmptyOrErrorState`, `DestructiveActionWarning` — icon **and** text, `role="alert"`.

**A11y & forms** — `Input` `aria-invalid` styling; Sign in / Sign up / Reset password now show accessible field + form-level errors, mark invalid fields, focus the first invalid one, and preserve entered values.

**Fixed leaks / boundaries** — `ErrorBoundary` + `RouteError` hide raw errors (dev-only), friendly copy + retry/home; router uses user-facing route labels.

**Backend** — global exception handler returns a friendly 500 envelope (traceback logged server-side only); the 3 leaky `detail=` messages replaced with plain language.

## Example before → after
| Before | After |
|---|---|
| "Oops! Something went wrong." + raw stack | "This page didn't load … it's not your fault — try again" + Retry/Home |
| "Failed to approve request" | "We couldn't approve this request. Please try again." |
| `detail: "Wrong email or password"` | "That email or password doesn't match. Check them and try again." |
| `Admin privileges required. Your role: student` | "You don't have permission to do this. Admin access is required." |
| red `<p>` under form, not announced | icon + text, `role="alert"`, `aria-invalid`, focus-to-first-invalid |

## Tests
- `errors.test.ts` — status→kind mapping, network detection, 422 field extraction, internal-leak sanitization, context/fallback.
- `errorComponents.test.tsx` — a11y roles, retry gating (transient vs 403).
- Full suite: **59 passing**; the one failure (`RequestFileModal.test.tsx`) is pre-existing on `main`, unrelated to this change. `tsc -b` and `vite build` clean.

## Follow-ups (product decisions)
- Wire a real monitoring service (Sentry) into `logger`/backend handler.
- Roll `toastError` / `EmptyOrErrorState` into the remaining feature hooks & list views (this PR covers auth, requests, boundaries, and the shared kit).
- Payment taxonomy is scaffolded but no checkout flow exists yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)