### PR TITLE
Allow admins to rename user-uploaded files

### DIFF
--- a/server/routers/admin.py
+++ b/server/routers/admin.py
@@ -9,7 +9,7 @@ from sqlmodel import Session, select, func
 from sqlalchemy import update, or_
 from database import get_session, engine
 from models import FileRequest, Course, Material, PointsTransaction, User, AuditLog, Lecturer, MaterialType, UserNotification, MaterialRequest
-from schemas import AdminRejectPayload, BulkActionPayload, BulkRejectPayload
+from schemas import AdminRejectPayload, AdminRequestUpdatePayload, BulkActionPayload, BulkRejectPayload
 from utils.auth_utils import get_admin_user
 from utils.shared import storage_client, BUCKET_NAME
 from utils.ai_utils import process_and_embed_pdf
@@ -285,6 +285,48 @@ def reject_request(
 
     session.commit()
     return {"message": "Request rejected and moved to trash for 3 days."}
+
+@router.patch("/api/v1/admin/requests/{request_id}")
+def rename_request(
+    request_id: UUID,
+    payload: AdminRequestUpdatePayload,
+    session: Session = Depends(get_session),
+    admin: User = Depends(get_admin_user)
+):
+    """Renames (edits the title of) a user-uploaded file request.
+
+    If the request has already been approved, the linked catalog Material is
+    kept in sync so the new title shows everywhere the file appears.
+    """
+    request = session.get(FileRequest, request_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Request not found.")
+
+    old_title = request.title
+    new_title = payload.title
+    if new_title == old_title:
+        return {"id": str(request.id), "title": request.title}
+
+    request.title = new_title
+
+    # Material.id == FileRequest.id (set explicitly at approval time). If this
+    # request was already approved, keep the published catalog entry in sync.
+    material = session.get(Material, request.id)
+    if material:
+        material.title = new_title
+
+    audit = AuditLog(
+        actor_id=admin.id,
+        actor_name=admin.name,
+        action="rename",
+        target_type="file_request",
+        target_ids=[str(request.id)],
+        meta_data={"from": old_title, "to": new_title}
+    )
+    session.add(audit)
+
+    session.commit()
+    return {"id": str(request.id), "title": request.title}
 
 # Gemini 1.5 free-tier limit: 15 RPM. We embed 1 API call per file,
 # so capping at 10 files/minute gives a comfortable safety buffer.

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -70,6 +70,18 @@ class FileRequestEnriched(BaseModel):
     admin_note: str | None = None
 
 # --- ADMIN PAYLOADS ---
+class AdminRequestUpdatePayload(BaseModel):
+    """Fields an admin may edit on a file request (currently just the title)."""
+    title: str = Field(min_length=1, max_length=200)
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def strip_title(cls, v: str) -> str:
+        stripped = v.strip() if isinstance(v, str) else v
+        if isinstance(stripped, str) and not stripped:
+            raise ValueError("Title must not be blank")
+        return stripped
+
 class BulkActionPayload(BaseModel):
     request_ids: List[UUID]
 

--- a/src/features/admin/components/RequestDetailSheet.tsx
+++ b/src/features/admin/components/RequestDetailSheet.tsx
@@ -10,7 +10,7 @@
 
 import * as React from "react";
 import { formatDate } from "@/lib/formatDate";
-import { FileText, Calendar, User, BookOpen, Tag, AlertTriangle, CheckCircle2, XCircle, Maximize2, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCw } from "lucide-react";
+import { FileText, Calendar, User, BookOpen, Tag, AlertTriangle, CheckCircle2, XCircle, Maximize2, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCw, Pencil, Check, X } from "lucide-react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
     Collapsible,
@@ -53,8 +54,10 @@ interface RequestDetailSheetProps {
     onOpenChange: (open: boolean) => void;
     onApprove: (requestId: string) => void;
     onReject: (requestId: string, reason: RejectReason, note?: string) => void;
+    onRename?: (requestId: string, title: string) => void;
     isApproving?: boolean;
     isRejecting?: boolean;
+    isRenaming?: boolean;
 }
 
 export function RequestDetailSheet({
@@ -63,8 +66,10 @@ export function RequestDetailSheet({
     onOpenChange,
     onApprove,
     onReject,
+    onRename,
     isApproving = false,
     isRejecting = false,
+    isRenaming = false,
 }: RequestDetailSheetProps) {
     const { data: previewData, isLoading: isLoadingPreview } = useRequestPreviewUrl(open && request ? request.id : undefined);
 
@@ -80,6 +85,16 @@ export function RequestDetailSheet({
     const [rejectDialogOpen, setRejectDialogOpen] = React.useState(false);
     const [duplicateWarningOpen, setDuplicateWarningOpen] = React.useState(false);
     const [fullscreenOpen, setFullscreenOpen] = React.useState(false);
+
+    // Inline title editing (admin rename)
+    const [isEditingTitle, setIsEditingTitle] = React.useState(false);
+    const [titleDraft, setTitleDraft] = React.useState("");
+
+    // Leaving edit mode whenever the sheet closes or a different request loads
+    // avoids a stale draft bleeding across requests.
+    React.useEffect(() => {
+        setIsEditingTitle(false);
+    }, [request?.id, open]);
 
     // Fullscreen viewer state
     const [numPages, setNumPages] = React.useState<number | null>(null);
@@ -108,6 +123,21 @@ export function RequestDetailSheet({
         setRejectDialogOpen(false);
     };
 
+    const startEditingTitle = () => {
+        setTitleDraft(request.title);
+        setIsEditingTitle(true);
+    };
+
+    const handleSaveTitle = () => {
+        const trimmed = titleDraft.trim();
+        if (!trimmed || trimmed === request.title) {
+            setIsEditingTitle(false);
+            return;
+        }
+        onRename?.(request.id, trimmed);
+        setIsEditingTitle(false);
+    };
+
     const statusBadge = {
         pending: <Badge variant="outline" className="bg-amber-500/15 text-amber-400 border-amber-500/30">Pending</Badge>,
         approved: <Badge variant="outline" className="bg-emerald-500/15 text-emerald-400 border-emerald-500/30">Approved</Badge>,
@@ -122,7 +152,60 @@ export function RequestDetailSheet({
                         <div className="flex items-center gap-2">
                             {statusBadge[request.status]}
                         </div>
-                        <SheetTitle className="text-lg">{request.title}</SheetTitle>
+                        {isEditingTitle ? (
+                            <div className="flex items-center gap-2">
+                                {/* Radix requires a title for a11y; keep one mounted while editing. */}
+                                <SheetTitle className="sr-only">Rename {request.title}</SheetTitle>
+                                <Input
+                                    value={titleDraft}
+                                    onChange={(e) => setTitleDraft(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter") { e.preventDefault(); handleSaveTitle(); }
+                                        if (e.key === "Escape") { e.preventDefault(); setIsEditingTitle(false); }
+                                    }}
+                                    autoFocus
+                                    maxLength={200}
+                                    disabled={isRenaming}
+                                    aria-label="File title"
+                                    className="h-9 text-base"
+                                />
+                                <Button
+                                    size="icon"
+                                    className="h-9 w-9 shrink-0 bg-green-600 hover:bg-green-700"
+                                    onClick={handleSaveTitle}
+                                    disabled={isRenaming || !titleDraft.trim()}
+                                    aria-label="Save title"
+                                >
+                                    <Check className="h-4 w-4" />
+                                </Button>
+                                <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-9 w-9 shrink-0"
+                                    onClick={() => setIsEditingTitle(false)}
+                                    disabled={isRenaming}
+                                    aria-label="Cancel rename"
+                                >
+                                    <X className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className="flex items-start gap-2">
+                                <SheetTitle className="text-lg flex-1 break-words">{request.title}</SheetTitle>
+                                {onRename && (
+                                    <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                                        onClick={startEditingTitle}
+                                        aria-label="Rename file"
+                                        title="Rename file"
+                                    >
+                                        <Pencil className="h-3.5 w-3.5" />
+                                    </Button>
+                                )}
+                            </div>
+                        )}
                         <SheetDescription>
                             Request ID: {request.id}
                         </SheetDescription>

--- a/src/features/admin/pages/AuditLog.tsx
+++ b/src/features/admin/pages/AuditLog.tsx
@@ -30,6 +30,7 @@ const actionConfig: Record<AuditAction, { label: string; variant: "default" | "s
     withdraw: { label: "Withdrawn", variant: "secondary" },
     undo_approve: { label: "Undo Approve", variant: "outline" },
     undo_reject: { label: "Undo Reject", variant: "outline" },
+    rename: { label: "Renamed", variant: "secondary" },
 };
 
 export default function AuditLog() {
@@ -43,6 +44,7 @@ export default function AuditLog() {
         if (meta.reason) parts.push(`Reason: ${meta.reason}`);
         if (meta.pointsAwarded) parts.push(`+${meta.pointsAwarded} pts`);
         if (meta.note) parts.push(`"${meta.note}"`);
+        if (meta.from || meta.to) parts.push(`"${meta.from ?? ""}" → "${meta.to ?? ""}"`);
         return parts.join(" · ");
     };
 

--- a/src/features/admin/pages/ModerationQueue.tsx
+++ b/src/features/admin/pages/ModerationQueue.tsx
@@ -32,7 +32,7 @@ import {
 import { BulkActionBar } from "@/features/admin/components/BulkActionBar";
 import { RejectDialog } from "@/features/admin/components/RejectDialog";
 import { RequestDetailSheet } from "@/features/admin/components/RequestDetailSheet";
-import { useAllRequests, useApproveRequest, useRejectRequest, useBulkApprove, useBulkReject, useRequestStats } from "@/features/files/hooks/useRequests";
+import { useAllRequests, useApproveRequest, useRejectRequest, useRenameRequest, useBulkApprove, useBulkReject, useRequestStats } from "@/features/files/hooks/useRequests";
 import type { FileRequest, FileStatus, RejectReason } from "@/types/domain";
 
 export default function ModerationQueue() {
@@ -57,6 +57,7 @@ export default function ModerationQueue() {
     const { data: stats } = useRequestStats();
     const approveMutation = useApproveRequest();
     const rejectMutation = useRejectRequest();
+    const renameMutation = useRenameRequest();
     const bulkApproveMutation = useBulkApprove();
     const bulkRejectMutation = useBulkReject();
 
@@ -91,6 +92,18 @@ export default function ModerationQueue() {
             onSuccess: () => {
                 setDetailSheetOpen(false);
             }
+        });
+    };
+
+    const handleRename = (requestId: string, title: string) => {
+        renameMutation.mutate({ requestId, title }, {
+            onSuccess: () => {
+                // Keep the open detail sheet in sync — selectedRequest is a local
+                // snapshot, separate from the invalidated query cache.
+                setSelectedRequest(prev =>
+                    prev && prev.id === requestId ? { ...prev, title } : prev
+                );
+            },
         });
     };
 
@@ -320,8 +333,10 @@ export default function ModerationQueue() {
                 onOpenChange={setDetailSheetOpen}
                 onApprove={handleApprove}
                 onReject={handleReject}
+                onRename={handleRename}
                 isApproving={approveMutation.isPending}
                 isRejecting={rejectMutation.isPending}
+                isRenaming={renameMutation.isPending}
             />
 
             {/* Bulk Reject Dialog */}

--- a/src/features/files/api/requestService.ts
+++ b/src/features/files/api/requestService.ts
@@ -117,6 +117,22 @@ export const rejectRequest = async (
 };
 
 /**
+ * Renames (edits the title of) a file request (admin only).
+ * Syncs the linked catalog Material title too if the request is already approved.
+ * Admin identity is derived from the JWT on the server — not sent in body.
+ * @backend PATCH /api/v1/admin/requests/:requestId
+ */
+export const renameRequest = async (
+    requestId: string,
+    title: string
+): Promise<{ id: string; title: string }> => {
+    return api<{ id: string; title: string }>(`/admin/requests/${requestId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ title }),
+    });
+};
+
+/**
  * Bulk approves multiple requests (admin only).
  * Admin identity is derived from the JWT on the server — not sent in body.
  * @backend POST /api/v1/admin/requests/bulk-approve

--- a/src/features/files/hooks/useRequests.ts
+++ b/src/features/files/hooks/useRequests.ts
@@ -33,6 +33,7 @@ import {
     listPendingRequests,
     approveRequest,
     rejectRequest,
+    renameRequest,
     bulkApprove,
     bulkReject,
     withdrawRequest,
@@ -230,6 +231,30 @@ export const useRejectRequest = () => {
         },
         onError: (err) => {
             toastError(err, { fallbackMessage: "We couldn't reject this request. Please try again." });
+        },
+    });
+};
+
+/**
+ * Mutation to rename (edit the title of) a file request.
+ * Admin identity comes from the JWT — not passed as arguments.
+ */
+export const useRenameRequest = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ requestId, title }: { requestId: string; title: string }) =>
+            renameRequest(requestId, title),
+        onSuccess: (result) => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.requests.all() });
+            queryClient.invalidateQueries({ queryKey: queryKeys.audit.all() });
+            // If the request was already approved, the catalog file lists/detail
+            // carry the old title — invalidate the whole ["files"] prefix.
+            queryClient.invalidateQueries({ queryKey: ["files"] });
+            toast.success(`Renamed to "${result.title}"`);
+        },
+        onError: (err) => {
+            toastError(err, { fallbackMessage: "We couldn't rename this file. Please try again." });
         },
     });
 };

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -306,7 +306,7 @@ export interface ActivitySummary {
 // ============================================================================
 
 /** Actions that can be performed by admins */
-export type AuditAction = "approve" | "reject" | "bulk_approve" | "bulk_reject" | "withdraw" | "undo_approve" | "undo_reject";
+export type AuditAction = "approve" | "reject" | "bulk_approve" | "bulk_reject" | "withdraw" | "undo_approve" | "undo_reject" | "rename";
 
 /** Standardized rejection reasons */
 export type RejectReason = "DUPLICATE" | "OUTDATED" | "INCORRECT_COURSE" | "BAD_QUALITY" | "OTHER";
@@ -329,6 +329,8 @@ export interface AuditLogEntry {
         pointsAwarded?: number;
         previousStatus?: FileStatus;
         newStatus?: FileStatus;
+        from?: string; // rename: previous title
+        to?: string;   // rename: new title
     };
 }
 


### PR DESCRIPTION
## What

Admins (and moderators, who inherit admin) can now **rename** a user-uploaded file — i.e. edit its title — from the Moderation Queue.

## How

- **Backend** — new `PATCH /api/v1/admin/requests/{request_id}` (`rename_request` in `server/routers/admin.py`) with `AdminRequestUpdatePayload` (`title`, trimmed, 1–200 chars).
  - Updates `FileRequest.title`.
  - If the request was **already approved**, keeps the linked catalog `Material.title` in sync (`Material.id == FileRequest.id`), so the new name shows everywhere the file appears.
  - Writes a `rename` audit-log entry with `{from, to}`.
- **Frontend**
  - Inline title editing in `RequestDetailSheet`: a pencil button swaps the title for an input with save/cancel (Enter saves, Escape cancels); a visually-hidden `SheetTitle` stays mounted while editing for a11y.
  - `renameRequest` service call + `useRenameRequest` hook (invalidates admin requests, audit logs, and the `["files"]` catalog cache; toasts success/error).
  - `ModerationQueue` wires the mutation and updates its local `selectedRequest` snapshot so the open sheet reflects the new title immediately.
  - Audit Log renders a **Renamed** badge and a `"old" → "new"` detail.

## Testing

- `tsc --noEmit` clean; changed files lint clean (one pre-existing `any` in untouched `createFileRequest`).
- `py_compile` passes for `schemas.py` and `routers/admin.py`.
- Full end-to-end drive not run locally — backend needs a live Postgres (per project notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)